### PR TITLE
Feat: 광고 데이터 불러오기 완성, 필터링 API 연동

### DIFF
--- a/Geeksasaeng/Geeksasaeng.xcodeproj/project.pbxproj
+++ b/Geeksasaeng/Geeksasaeng.xcodeproj/project.pbxproj
@@ -940,6 +940,9 @@
 		A2211118287F748900A8EEFB /* WeeklyTopCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2211117287F748900A8EEFB /* WeeklyTopCollectionViewCell.swift */; };
 		A2211119287F748900A8EEFB /* WeeklyTopCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2211117287F748900A8EEFB /* WeeklyTopCollectionViewCell.swift */; };
 		A221111A287F748900A8EEFB /* WeeklyTopCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2211117287F748900A8EEFB /* WeeklyTopCollectionViewCell.swift */; };
+		A234E2A72884443A0056AA36 /* FilteringViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A234E2A62884443A0056AA36 /* FilteringViewModel.swift */; };
+		A234E2A82884443A0056AA36 /* FilteringViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A234E2A62884443A0056AA36 /* FilteringViewModel.swift */; };
+		A234E2A92884443A0056AA36 /* FilteringViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A234E2A62884443A0056AA36 /* FilteringViewModel.swift */; };
 		A2513ECA28781D1B0029C279 /* PhoneAuthModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2513EC928781D1B0029C279 /* PhoneAuthModel.swift */; };
 		A2513ECB28781D1B0029C279 /* PhoneAuthModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2513EC928781D1B0029C279 /* PhoneAuthModel.swift */; };
 		A2513ECC28781D1B0029C279 /* PhoneAuthModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2513EC928781D1B0029C279 /* PhoneAuthModel.swift */; };
@@ -1361,6 +1364,7 @@
 		A20FC0F0287F30C40095224C /* SeachVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeachVC.swift; sourceTree = "<group>"; };
 		A20FC0F4287F61810095224C /* RecentSearchCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchCollectionViewCell.swift; sourceTree = "<group>"; };
 		A2211117287F748900A8EEFB /* WeeklyTopCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyTopCollectionViewCell.swift; sourceTree = "<group>"; };
+		A234E2A62884443A0056AA36 /* FilteringViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilteringViewModel.swift; sourceTree = "<group>"; };
 		A2513EC928781D1B0029C279 /* PhoneAuthModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneAuthModel.swift; sourceTree = "<group>"; };
 		A2513F0C2878261F0029C279 /* PhoneAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneAuthViewModel.swift; sourceTree = "<group>"; };
 		A2513F1028785FA30029C279 /* PhoneAuthCheckModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneAuthCheckModel.swift; sourceTree = "<group>"; };
@@ -1452,8 +1456,9 @@
 				A2513F0C2878261F0029C279 /* PhoneAuthViewModel.swift */,
 				A2513F142878612B0029C279 /* PhoneAuthCheckViewModel.swift */,
 				A2E641652879DD6100B40A63 /* UniversityListViewModel.swift */,
-				A20FC0E8287F1B1F0095224C /* DeliveryListViewModel.swift */,
 				A2035EA028833ED60051498A /* AdViewModel.swift */,
+				A20FC0E8287F1B1F0095224C /* DeliveryListViewModel.swift */,
+				A234E2A62884443A0056AA36 /* FilteringViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -3115,6 +3120,7 @@
 				A2FA89AA286ECD4200CB3B55 /* UIColor+Extension.swift in Sources */,
 				106D9755287D7C32005CFB85 /* CategoryVC.swift in Sources */,
 				1040FB9A2875CC600060A3E4 /* PhoneAuthVC.swift in Sources */,
+				A234E2A72884443A0056AA36 /* FilteringViewModel.swift in Sources */,
 				1040FB982875C06E0060A3E4 /* AgreementVC.swift in Sources */,
 				A2B42088286F0F1100278F92 /* EmailAuthVC.swift in Sources */,
 			);
@@ -3155,6 +3161,7 @@
 				A2085AE02870550200D6CF79 /* LoginModel.swift in Sources */,
 				102B35DD2879BD670042F691 /* UIViewController+Extension.swift in Sources */,
 				10C8D26928770D310044552A /* NaverRegisterVC.swift in Sources */,
+				A234E2A82884443A0056AA36 /* FilteringViewModel.swift in Sources */,
 				10A53C742882FA6D00DDCE87 /* APIKEY.swift in Sources */,
 				A20FC0F2287F30C40095224C /* SeachVC.swift in Sources */,
 				106D975F287D9A92005CFB85 /* CreatePartyAPI.swift in Sources */,
@@ -3188,6 +3195,7 @@
 				A2AC91DC2874D3B600C7CF64 /* NaverLoginViewModel.swift in Sources */,
 				106D975B287D8735005CFB85 /* ReceiptPlaceVC.swift in Sources */,
 				A2035EA328833ED60051498A /* AdViewModel.swift in Sources */,
+				A234E2A92884443A0056AA36 /* FilteringViewModel.swift in Sources */,
 				105E60AB287C32710030C927 /* CreatePartyVC.swift in Sources */,
 				A2513ECC28781D1B0029C279 /* PhoneAuthModel.swift in Sources */,
 				A2F54FD928757CDF0094C18D /* AdCollectionViewCell.swift in Sources */,
@@ -3224,7 +3232,6 @@
 				102B35D22879BCD60042F691 /* UIView+Extension.swift in Sources */,
 				A2FA89B0286EDD7E00CB3B55 /* UIFont+Extension.swift in Sources */,
 				10A53C752882FA6D00DDCE87 /* APIKEY.swift in Sources */,
-				A219B275287575E4000F34A3 /* AdCarouselModel.swift in Sources */,
 				A2513F0F2878261F0029C279 /* PhoneAuthViewModel.swift in Sources */,
 				1040FB9E2875CC640060A3E4 /* AgreementVC.swift in Sources */,
 				A20FC0F3287F30C40095224C /* SeachVC.swift in Sources */,

--- a/Geeksasaeng/Geeksasaeng/Model/DeliveryListModel.swift
+++ b/Geeksasaeng/Geeksasaeng/Model/DeliveryListModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// Response
+// 배달 목록 불러오기 Response
 struct DeliveryListModel: Decodable {
     var code: Int?
     var isSuccess: Bool?
@@ -17,14 +17,9 @@ struct DeliveryListModel: Decodable {
 
 struct DeliveryListModelResult: Decodable {
     var id: Int?
-    var chief: String?
-    var foodCategory: String?
-    var hashTags: [String]?
     var title: String?
-    var content: String?
     var orderTime: String?
     var currentMatching: Int?
     var maxMatching: Int?
-    var location: String?
-    var matchingStatus: String?
+    var hashTags: [String]?
 }

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/DeliveryVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/DeliveryVC.swift
@@ -29,6 +29,11 @@ class DeliveryViewController: UIViewController {
     
     // 배달 목록 화면 처음 킨 건지 여부 확인
     var isInitial = true
+    
+    // 필터링이 설정되어 있는지/아닌지 여부 확인
+//    var isPeopleFilterOn = false
+//    var isTimeFilterOn = false
+
     // 목록에서 현재 커서 위치
     var cursor = 0
     // 배달 목록 데이터가 저장되는 배열
@@ -190,7 +195,7 @@ class DeliveryViewController: UIViewController {
         return view
     }()
     // 점심
-    var launchFilterView: UIView = {
+    var lunchFilterView: UIView = {
         let view = UIView()
         view.backgroundColor = .init(hex: 0xF8F8F8)
         view.layer.cornerRadius = 3
@@ -261,7 +266,7 @@ class DeliveryViewController: UIViewController {
     
     /* 시간 관련 필터뷰들을 묶어놓는 스택뷰 */
     lazy var timeOptionStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [breakfastFilterView, launchFilterView, dinnerFilterView, midnightSnackFilterView])
+        let stackView = UIStackView(arrangedSubviews: [breakfastFilterView, lunchFilterView, dinnerFilterView, midnightSnackFilterView])
         stackView.spacing = 10
         return stackView
     }()
@@ -553,6 +558,104 @@ class DeliveryViewController: UIViewController {
         }
     }
     
+//    private func getPeopleFilterList(text: String?) {
+//        isPeopleFilterOn = true
+//
+//        print("TEST: ", text)
+//        var num: Int? = nil
+//        switch text {
+//        case "2명 이하":
+//            num = 2
+//        case "4명 이하":
+//            num = 4
+//        case "6명 이하":
+//            num = 6
+//        case "8명 이하":
+//            num = 8
+//        case "10명 이하":
+//            num = 10
+//        default:
+//            num = nil
+//        }
+//        print("TEST: ", num)
+//
+//        if let num = num {
+//            cursor = 0
+//            // TODO: - 추후에 기숙사 정보 불러와서 dormitoryId로 넣기
+//            FilteringViewModel.requestGetPeopleFilter(cursor: cursor, dormitoryId: 1, maxMatching: num) { [weak self] result in
+//                switch result {
+//                case .success(let result):
+//                    if result.isSuccess! {
+//                        print("DEBUG: 인원수 필터링 배달 목록 받아오기 성공")
+//                        self?.deliveryCellDataArray.removeAll()
+//                        result.result?.forEach {
+//                            // 데이터를 배열에 추가
+//                            self?.deliveryCellDataArray.append($0)
+//                            print("DEBUG: 받아온 배달 데이터(인원수 필터링)", $0)
+//                        }
+//                        // 테이블뷰 리로드
+//                        DispatchQueue.main.async {
+//                            self?.partyTableView.reloadData()
+//                        }
+//                    } else {
+//                        print("DEBUG: 실패", result.message!)
+//                    }
+//                case .failure(let error):
+//                    print("DEBUG:", error.localizedDescription)
+//                }
+//            }
+//        }
+//    }
+//
+//    private func getTimeFilterList(text: String?) {
+//        isTimeFilterOn = true
+//
+//        // label에 따라 다른 값을 넣어 시간으로 필터링된 배달 목록을 불러온다
+//        enum TimeOption: String {
+//            case breakfast = "BREAKFAST"
+//            case lunch = "LUNCH"
+//            case dinner = "DINNER"
+//            case midnightSnacks = "MIDNIGHT_SNACKS"
+//        }
+//        var category: String = ""
+//
+//        switch text {
+//        case "아침" :
+//            category = TimeOption.breakfast.rawValue
+//        case "점심" :
+//            category = TimeOption.lunch.rawValue
+//        case "저녁" :
+//            category = TimeOption.dinner.rawValue
+//        case "야식" :
+//            category = TimeOption.midnightSnacks.rawValue
+//        default :
+//            category = ""
+//        }
+//
+//        FilteringViewModel.requestGetTimeFilter(cursor: cursor, dormitoryId: 1, orderTimeCategory: category) { [weak self] result in
+//            switch result {
+//            case .success(let result):
+//                if result.isSuccess! {
+//                    print("DEBUG: 시간 필터링 배달 목록 받아오기 성공")
+//                    self?.deliveryCellDataArray.removeAll()
+//                    result.result?.forEach {
+//                        // 데이터를 배열에 추가
+//                        self?.deliveryCellDataArray.append($0)
+//                        print("DEBUG: 받아온 배달 데이터(시간 필터링)", $0)
+//                        self?.partyTableView.reloadData()
+//                    }
+////                        // 테이블뷰 리로드
+////                        DispatchQueue.main.async {
+////                        }
+//                } else {
+//                    print("DEBUG: 실패", result.message!)
+//                }
+//            case .failure(let error):
+//                print("DEBUG:", error.localizedDescription)
+//            }
+//        }
+//    }
+    
     /* 무한 스크롤로 마지막 데이터까지 가면 나오는(= FooterView) 데이터 로딩 표시 생성 */
     private func createSpinnerFooter() -> UIView {
         let footerView = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: 100))
@@ -729,6 +832,9 @@ class DeliveryViewController: UIViewController {
         // peopleFilterView의 텍스트를 label로 변경함
         peopleFilterLabel.text = label.text
         
+        // TODO: - 인원수 필터링 호출 -> 서버에 (필터링 API 두개 + 전체 목록 불러오는 API)를 하나로 합치는 거 제안. 추후에 API 완성되면 수정 예정.
+//        self.getPeopleFilterList(text: label.text)
+        
         for view in peopleOptionStackView.subviews {
             let label = view as! UILabel
             if label.text != peopleFilterLabel.text {
@@ -741,12 +847,17 @@ class DeliveryViewController: UIViewController {
     @objc private func tapTimeOption(sender: UIGestureRecognizer) {
         let label = sender.view as! UILabel
         
-        // label 색 변경 - mainColor로
+//        cursor = 0
+        
+        // label 색 변경 - mainColor로 -> 필터가 선택된 것
         if label.textColor != .mainColor {
             label.textColor = .mainColor
+            // TODO: - 시간 필터링 호출
+//            getTimeFilterList(text: label.text)
         } else {
             // 원래 색깔로 되돌려 놓는다
             label.textColor = .init(hex: 0xD8D8D8)
+//            getDeliveryList()
         }
     }
     
@@ -817,8 +928,8 @@ class DeliveryViewController: UIViewController {
             let position = scrollView.contentOffset.y
             print("pos", position)
             // 마지막 데이터에 도달했을 때
-            print(partyTableView.contentSize.height)
-                  print(scrollView.frame.size.height)
+//            print(partyTableView.contentSize.height)
+//            print(scrollView.frame.size.height)
             if position > (partyTableView.contentSize.height - scrollView.frame.size.height) {
                 // 다음 커서의 배달 목록을 불러온다
                 cursor += 1
@@ -856,7 +967,7 @@ extension DeliveryViewController: UITableViewDataSource, UITableViewDelegate {
             // TODO: - 추후에 모델이나 뷰모델로 위치 옮기면 될 듯
             // 서버에서 받은 데이터의 형식대로 날짜 포맷팅
             let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+            formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
             formatter.locale = Locale(identifier: "ko_KR")
             formatter.timeZone = TimeZone(abbreviation: "KST")
             
@@ -927,9 +1038,6 @@ extension DeliveryViewController: UICollectionViewDataSource, UICollectionViewDe
         if let imgString = adCellDataArray[indexPath.item].imgUrl {
             let url = URL(string: imgString)
             cell.cellImageView.kf.setImage(with: url)
-            if cell.cellImageView.image == nil {
-                print("이미지가 없어요")
-            }
         }
 //        print("DEBUG: ", adCellDataArray[indexPath.item].cellImagePath)
         

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/DeliveryVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/DeliveryVC.swift
@@ -17,6 +17,8 @@ class DeliveryViewController: UIViewController {
     var adCellDataArray: [AdModelResult] = [] {
         didSet {
             print("광고!", adCellDataArray)
+            // 새 값을 받으면 컬렉션뷰 리로드!
+            adCollectionView.reloadData()
         }
     }
     // 광고 배너의 현재 페이지를 체크하는 변수 (자동 스크롤할 때 필요)
@@ -925,6 +927,9 @@ extension DeliveryViewController: UICollectionViewDataSource, UICollectionViewDe
         if let imgString = adCellDataArray[indexPath.item].imgUrl {
             let url = URL(string: imgString)
             cell.cellImageView.kf.setImage(with: url)
+            if cell.cellImageView.image == nil {
+                print("이미지가 없어요")
+            }
         }
 //        print("DEBUG: ", adCellDataArray[indexPath.item].cellImagePath)
         

--- a/Geeksasaeng/Geeksasaeng/ViewModel/FilteringViewModel.swift
+++ b/Geeksasaeng/Geeksasaeng/ViewModel/FilteringViewModel.swift
@@ -1,0 +1,52 @@
+//
+//  FilteringViewModel.swift
+//  Geeksasaeng
+//
+//  Created by 서은수 on 2022/07/17.
+//
+
+import Foundation
+import Alamofire
+
+/* 필터링된 배달 목록을 가져오는 API 호출 */
+class FilteringViewModel {
+    
+    // escaping을 통해 이 함수를 호출한 부분의 클로저로 결과 값을 넘겨줌 -> 호출한 VC에서 처리 가능해짐
+    /* 인원수 필터링된 배달 목록 데이터를 불러온다 */
+    public static func requestGetPeopleFilter(cursor: Int, dormitoryId: Int, maxMatching: Int, completion: @escaping (Result<DeliveryListModel, AFError>) -> Void) {
+        let url = "https://geeksasaeng.shop/\(dormitoryId)/delivery-parties/\(maxMatching)"
+        let parameters: Parameters = [
+            "cursor": cursor
+        ]
+        
+        // 데이터를 새로 읽어온다는 느낌을 주기 위해 1.5초 딜레이
+        DispatchQueue.global().asyncAfter(deadline: .now() + 1.5, execute: {
+            AF.request(url, method: .get, parameters: parameters,
+                       encoding: URLEncoding(destination: .queryString))
+            .validate()
+            .responseDecodable(of: DeliveryListModel.self) { response in
+                // completion으로 result 넘겨줌
+                completion(response.result)
+            }
+        })
+    }
+    
+    /* 시간 필터링된 배달 목록 데이터를 불러온다 */
+    public static func requestGetTimeFilter(cursor: Int, dormitoryId: Int, orderTimeCategory: String, completion: @escaping (Result<DeliveryListModel, AFError>) -> Void) {
+        let url = "https://geeksasaeng.shop/\(dormitoryId)/delivery-parties/filter/\(orderTimeCategory)"
+        let parameters: Parameters = [
+            "cursor": cursor
+        ]
+        
+        // 데이터를 새로 읽어온다는 느낌을 주기 위해 1.5초 딜레이
+        DispatchQueue.global().asyncAfter(deadline: .now() + 1.5, execute: {
+            AF.request(url, method: .get, parameters: parameters,
+                       encoding: URLEncoding(destination: .queryString))
+            .validate()
+            .responseDecodable(of: DeliveryListModel.self) { response in
+                // completion으로 result 넘겨줌
+                completion(response.result)
+            }
+        })
+    }
+}


### PR DESCRIPTION
Feat
- 광고 데이터 불러오기 완성 -> 이제 광고 사진 뷰에서 잘 보임
- 매칭 인원수 필터링 API 연동
- 주문 예정 시간 필터링 API 연동
    -> 연동은 했으나 데이터를 배열에 받아 뷰로 보여주는 과정에서 문제 발견
    -> 인원수 필터링과 시간 필터링이 복수 선택이 가능해서 둘의 교집합을 뷰에 보여주는 과정에서 문제 봉착
    -> 두 개의 API가 각각이라 하나로 합치는 것 서버에 제안
    -> 전체 목록 조회 + 인원수 필터링 + 시간 필터링 을 하나의 API로 해결하게 수정한다고 함
    -> 그래서 여기서 짠 코드 안 쓸 듯... 혹시 몰라서 지우진 않고 주석 처리해서 pr 보냅니다

