### PR TITLE
Seori

### DIFF
--- a/Geeksasaeng/Geeksasaeng.xcodeproj/project.pbxproj
+++ b/Geeksasaeng/Geeksasaeng.xcodeproj/project.pbxproj
@@ -2303,14 +2303,14 @@
 		A2B4208E286F1F0500278F92 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				102B35DF2879BD980042F691 /* String+Extension.swift */,
 				A2FA89A9286ECD4200CB3B55 /* UIColor+Extension.swift */,
-				A2FA89AD286EDD7E00CB3B55 /* UIFont+Extension.swift */,
 				102B35CF2879BCD60042F691 /* UIView+Extension.swift */,
+				A2FA89AD286EDD7E00CB3B55 /* UIFont+Extension.swift */,
+				10B3822128A2321F00571406 /* UILabel+Extension.swift */,
 				102B35D32879BCF90042F691 /* UITextField+Extension.swift */,
 				102B35D72879BD050042F691 /* UIButton+Extension.swift */,
 				102B35DB2879BD670042F691 /* UIViewController+Extension.swift */,
-				102B35DF2879BD980042F691 /* String+Extension.swift */,
-				10B3822128A2321F00571406 /* UILabel+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";

--- a/Geeksasaeng/Geeksasaeng.xcodeproj/project.pbxproj
+++ b/Geeksasaeng/Geeksasaeng.xcodeproj/project.pbxproj
@@ -3894,7 +3894,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.geeksasaeng;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "/Users/jodongjin/Desktop/UMC/Geeksasaeng/Geek_sasaeng-iOS/Geeksasaeng/Geeksasaeng/Kakao-Map-Bridge-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "/Users/seori/Desktop/Geek_sasaeng-iOS/Geeksasaeng/Geeksasaeng/Kakao-Map-Bridge-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				VALIDATE_WORKSPACE = NO;
@@ -3933,7 +3933,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.geeksasaeng;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "/Users/jodongjin/Desktop/UMC/Geeksasaeng/Geek_sasaeng-iOS/Geeksasaeng/Geeksasaeng/Kakao-Map-Bridge-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "/Users/seori/Desktop/Geek_sasaeng-iOS/Geeksasaeng/Geeksasaeng/Kakao-Map-Bridge-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				VALIDATE_WORKSPACE = NO;

--- a/Geeksasaeng/Geeksasaeng/Extension/UIViewController+Extension.swift
+++ b/Geeksasaeng/Geeksasaeng/Extension/UIViewController+Extension.swift
@@ -37,6 +37,15 @@ extension UIViewController {
         })
     }
     
+    /* 배경에 어두운 블러뷰 만드는 함수 */
+    public func setDarkBlurView() -> UIVisualEffectView {
+        let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
+        visualEffectView.layer.opacity = 0.6
+        visualEffectView.frame = view.frame
+        view.addSubview(visualEffectView)
+        return visualEffectView
+    }
+    
     /* 왼쪽에서 오른쪽으로 Swipe Gesture Recognizer를 추가하는 함수 */
     public func addRightSwipe() {
         let rightSwipe = UISwipeGestureRecognizer(target: self, action: #selector(self.swipeAction(swipe:)))

--- a/Geeksasaeng/Geeksasaeng/Network/ReportAPI.swift
+++ b/Geeksasaeng/Geeksasaeng/Network/ReportAPI.swift
@@ -35,7 +35,7 @@ struct ReportModel : Decodable {
 class ReportAPI {
     
     /* 신고하기 버튼을 눌러서 파티 신고 요청 */
-    public static func requestReportParty(_ viewController : UIViewController, _ parameter : ReportPartyInput, completion: @escaping () -> Void) {
+    public static func requestReportParty(_ parameter : ReportPartyInput, completion: @escaping (Bool, String?) -> Void) {
         let url = "https://geeksasaeng.shop/reports/delivery-parties"
         
         AF.request(url, method: .post,
@@ -46,19 +46,20 @@ class ReportAPI {
             case .success(let result):
                 if result.isSuccess! {
                     print("DEBUG: 파티 신고 성공", result)
-                    viewController.showToast(viewController: viewController, message: "파티 신고가 완료되었습니다.", font: .customFont(.neoBold, size: 15), color: .mainColor)
-                    completion()
+                    completion(result.isSuccess!, nil)
                 } else {
                     print("DEBUG:", result.message!)
+                    completion(result.isSuccess!, result.message!)
                 }
             case .failure(let error):
                 print("DEBUG:", error.localizedDescription)
+                completion(false, "오류가 발생하여 신고가 제출되지 않았습니다")
             }
         }
     }
     
     /* 신고하기 버튼을 눌러서 멤버 신고 요청 */
-    public static func requestReportMember(_ viewController : UIViewController, _ parameter : ReportMemberInput, completion: @escaping () -> Void) {
+    public static func requestReportMember(_ parameter : ReportMemberInput, completion: @escaping (Bool, String?) -> Void) {
         let url = "https://geeksasaeng.shop/reports/members"
         
         AF.request(url, method: .post,
@@ -69,13 +70,14 @@ class ReportAPI {
             case .success(let result):
                 if result.isSuccess! {
                     print("DEBUG: 유저 신고 성공", result)
-                    viewController.showToast(viewController: viewController, message: "유저 신고가 완료되었습니다.", font: .customFont(.neoBold, size: 15), color: .mainColor)
-                    completion()
+                    completion(result.isSuccess!, nil)
                 } else {
                     print("DEBUG:", result.message!)
+                    completion(result.isSuccess!, result.message!)
                 }
             case .failure(let error):
                 print("DEBUG:", error.localizedDescription)
+                completion(false, "오류가 발생하여 신고가 제출되지 않았습니다")
             }
         }
     }

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Chat/ChattingListVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Chat/ChattingListVC.swift
@@ -288,6 +288,26 @@ extension ChattingListViewController: UITableViewDataSource, UITableViewDelegate
         let index = indexPath.row
         // 채팅방 타이틀 설정
         cell.titleLabel.text = chattingRoomList[index].title ?? "디폴트 이름"
+        
+        /* firestore에서 채팅방의 가장 최근 메세지, 전송 시간 데이터 가져오기 */
+        let roomDocRef = db.collection("Rooms").document(roomUUIDList[indexPath.row])
+        // 해당 채팅방의 messages를 time을 기준으로 내림차순 정렬 후 처음의 1개(= 가장 최근 메세지)만 가져온다.
+        roomDocRef.collection("Messages").order(by: "time", descending: true).limit(to: 1) .addSnapshotListener { querySnapshot, error in
+                if let error = error {
+                    print("Error retreiving collection: \(error)")
+                }
+                if let querySnapshot = querySnapshot,
+                   let lastDocument = querySnapshot.documents.last {
+                    if let messageContents = lastDocument["content"] as? String,
+                       let messageTime = lastDocument["time"] as? String {
+                        // 채팅방의 최근 메세지 설정
+                        cell.recentMessageLabel.text = messageContents
+                        // 최근 메세지의 전송 시간 설정
+                        cell.receivedTimeLabel.text = messageTime
+                    }
+                }
+            }
+        
         return cell
     }
 

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Chat/ChattingVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Chat/ChattingVC.swift
@@ -91,10 +91,11 @@ class ChattingViewController: UIViewController {
             button.makeBottomLine(color: 0xEFEFEF, width: view.bounds.width - 40, height: 1, offsetToTop: 13)
             return button
         }()
-        var CloseMatchingButton: UIButton = {
+        var closeMatchingButton: UIButton = {
             let button = UIButton()
             button.setTitle("매칭 마감하기", for: .normal)
             button.makeBottomLine(color: 0xEFEFEF, width: view.bounds.width - 40, height: 1, offsetToTop: 13)
+            button.addTarget(self, action: #selector(tapCloseMatchingButton), for: .touchUpInside)
             return button
         }()
         var forcedExitButton: UIButton = {
@@ -110,7 +111,7 @@ class ChattingViewController: UIViewController {
             return button
         }()
         
-        [showMenuButton, sendDeliveryConfirmButton, CloseMatchingButton, forcedExitButton, endOfChatButton].forEach {
+        [showMenuButton, sendDeliveryConfirmButton, closeMatchingButton, forcedExitButton, endOfChatButton].forEach {
             // attributes
             $0.setTitleColor(UIColor.init(hex: 0x2F2F2F), for: .normal)
             $0.titleLabel?.font =  .customFont(.neoMedium, size: 18)
@@ -126,12 +127,12 @@ class ChattingViewController: UIViewController {
             make.top.equalTo(showMenuButton.snp.bottom).offset(27)
             make.centerX.equalToSuperview()
         }
-        CloseMatchingButton.snp.makeConstraints { make in
+        closeMatchingButton.snp.makeConstraints { make in
             make.top.equalTo(sendDeliveryConfirmButton.snp.bottom).offset(27)
             make.centerX.equalToSuperview()
         }
         forcedExitButton.snp.makeConstraints { make in
-            make.top.equalTo(CloseMatchingButton.snp.bottom).offset(27)
+            make.top.equalTo(closeMatchingButton.snp.bottom).offset(27)
             make.centerX.equalToSuperview()
         }
         endOfChatButton.snp.makeConstraints { make in
@@ -229,6 +230,106 @@ class ChattingViewController: UIViewController {
         confirmButton.setTitle("확인", for: .normal)
         confirmButton.titleLabel?.font = .customFont(.neoBold, size: 18)
         confirmButton.addTarget(self, action: #selector(tapExitConfirmButton), for: .touchUpInside)
+        confirmButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(lineView.snp.bottom).offset(18)
+            make.width.height.equalTo(34)
+        }
+        
+        return view
+    }()
+    
+    /* 매칭 마감하기 누르면 나오는 매칭마감 안내 뷰 */
+    lazy var closeMatchingView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 7
+        view.snp.makeConstraints { make in
+            make.width.equalTo(256)
+            make.height.equalTo(250)
+        }
+        
+        /* top View */
+        let topSubView = UIView()
+        topSubView.backgroundColor = UIColor(hex: 0xF8F8F8)
+        view.addSubview(topSubView)
+        topSubView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.width.equalToSuperview()
+            make.height.equalTo(50)
+        }
+        
+        /* set titleLabel */
+        let titleLabel = UILabel()
+        titleLabel.text = "매칭 마감하기"
+        titleLabel.textColor = UIColor(hex: 0xA8A8A8)
+        titleLabel.font = .customFont(.neoMedium, size: 14)
+        topSubView.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+        
+        /* set cancelButton */
+        lazy var cancelButton = UIButton()
+        cancelButton.setImage(UIImage(named: "Xmark"), for: .normal)
+        cancelButton.addTarget(self, action: #selector(removeCloseMatchingView), for: .touchUpInside)
+        topSubView.addSubview(cancelButton)
+        cancelButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.width.equalTo(20)
+            make.height.equalTo(12)
+            make.right.equalToSuperview().offset(-15)
+        }
+        
+        /* bottom View: contents, 확인 버튼 */
+        let bottomSubView = UIView()
+        bottomSubView.backgroundColor = UIColor.white
+        view.addSubview(bottomSubView)
+        bottomSubView.snp.makeConstraints { make in
+            make.top.equalTo(topSubView.snp.bottom)
+            make.width.equalToSuperview()
+            make.height.equalTo(200)
+        }
+        
+        let contentLabel = UILabel()
+        let lineView = UIView()
+        lazy var confirmButton = UIButton()
+        
+        [contentLabel, lineView, confirmButton].forEach {
+            bottomSubView.addSubview($0)
+        }
+        
+        /* set contentLabel */
+        contentLabel.text = "매칭을 종료할 시\n본 파티에 대한 추가 인원이\n더 이상 모집되지 않습니다.\n계속하시겠습니까?"
+        contentLabel.numberOfLines = 0
+        contentLabel.textColor = .init(hex: 0x2F2F2F)
+        contentLabel.font = .customFont(.neoMedium, size: 14)
+        let attrString = NSMutableAttributedString(string: contentLabel.text!)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 6
+        paragraphStyle.alignment = .center
+        attrString.addAttribute(NSAttributedString.Key.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attrString.length))
+        contentLabel.attributedText = attrString
+        contentLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().inset(20)
+        }
+        
+        /* set lineView */
+        lineView.backgroundColor = UIColor(hex: 0xEFEFEF)
+        lineView.snp.makeConstraints { make in
+            make.top.equalTo(contentLabel.snp.bottom).offset(15)
+            make.left.equalTo(18)
+            make.right.equalTo(-18)
+            make.height.equalTo(1.7)
+        }
+        
+        /* set confirmButton */
+        confirmButton.setTitleColor(.mainColor, for: .normal)
+        confirmButton.setTitle("확인", for: .normal)
+        confirmButton.titleLabel?.font = .customFont(.neoBold, size: 18)
+        confirmButton.addTarget(self, action: #selector(tapConfirmButton), for: .touchUpInside)
         confirmButton.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.top.equalTo(lineView.snp.bottom).offset(18)
@@ -502,11 +603,40 @@ class ChattingViewController: UIViewController {
         self.bottomView.transform = .identity
     }
     
-    @objc func tapCollectionView() {
+    /* 매칭 마감하기 버튼 누르면 실행되는 함수 */
+    @objc
+    private func tapCloseMatchingButton() {
+        optionViewForOwner.removeFromSuperview()
+        
+        /* 매칭 마감 뷰 보여줌 */
+        view.addSubview(closeMatchingView)
+        closeMatchingView.snp.makeConstraints { make in
+            make.centerX.centerY.equalToSuperview()
+        }
+    }
+    
+    /* 매칭 마감하기 뷰에서 X자 눌렀을 때 실행되는 함수 */
+    @objc
+    private func removeCloseMatchingView() {
+        closeMatchingView.removeFromSuperview()
+        visualEffectView?.removeFromSuperview()
+    }
+    
+    /* 매칭 마감하기 뷰에서 확인 눌렀을 때 실행되는 함수 */
+    @objc
+    private func tapConfirmButton() {
+        // TODO: - 매칭 마감하기 API 연동
+        
+        // 매칭 마감하기 뷰 없애기
+        removeCloseMatchingView()
+    }
+    
+    @objc
+    private func tapCollectionView() {
         view.endEditing(true)
         
         if visualEffectView != nil { // nil이 아니라면, 즉 옵션뷰가 노출되어 있다면
-            showChattRoom(optionViewForOwner)
+            showChattingRoom(optionViewForOwner)
             view.subviews.forEach {
                 if $0 == exitView {
                     $0.removeFromSuperview()
@@ -515,7 +645,8 @@ class ChattingViewController: UIViewController {
         }
     }
     
-    @objc func tapSendButton() {
+    @objc
+    private func tapSendButton() {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         formatter.locale = Locale(identifier: "ko_KR")
@@ -545,10 +676,10 @@ class ChattingViewController: UIViewController {
     private func tapOptionButtonInView(_ sender: UIButton) {
         // 클릭한 버튼의 superView가 그냥 optionView인지 optionViewForAuthor인지 파라미터로 보내주는 것
         guard let nowView = sender.superview else { return }
-        showChattRoom(nowView)
+        showChattingRoom(nowView)
     }
     
-    private func showChattRoom(_ nowView: UIView) {
+    private func showChattingRoom(_ nowView: UIView) {
         UIView.animate(
             withDuration: 0.3,
             delay: 0.1,

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/DeliveryVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/DeliveryVC.swift
@@ -337,7 +337,7 @@ class DeliveryViewController: UIViewController {
         
         makeButtonShadow(createPartyButton)
         if let jwt = LoginModel.jwt {
-            print("====\(jwt)====")
+            print("DEBUG: jwt \(jwt)")
         }
         
         /* 광고 목록 데이터 로딩 */

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/Agreement/AgreementVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/Agreement/AgreementVC.swift
@@ -161,6 +161,7 @@ class AgreementViewController: UIViewController {
         
         addSubViews()
         setLayouts()
+        addRightSwipe()
     }
     
     // MARK: - Function

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/Agreement/TermsOfUseAgreementVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/Agreement/TermsOfUseAgreementVC.swift
@@ -51,6 +51,7 @@ class TermsOfUseAgreementViewController: UIViewController {
         
         addSubViews()
         setLayouts()
+        addRightSwipe()
     }
     
     private func addSubViews() {

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/AuthNumVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/AuthNumVC.swift
@@ -303,9 +303,9 @@ class AuthNumViewController: UIViewController {
                 phoneAuthVC.university = univ
                 phoneAuthVC.emailId = emailId
                 phoneAuthVC.uuid = uuid
+                
+                present(phoneAuthVC, animated: true)
             }
-            
-            present(phoneAuthVC, animated: true)
         }
     }
 }

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/AuthNumVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/AuthNumVC.swift
@@ -261,7 +261,10 @@ class AuthNumViewController: UIViewController {
             
             let input = EmailAuthInput(email: email, university: univ)
             // 이메일로 인증번호 전송하는 API 호출
-            EmailAuthViewModel.requestSendEmail(self, input)
+            EmailAuthViewModel.requestSendEmail(input) { isSuccess, message in
+                // 경우에 맞는 토스트 메세지 출력
+                self.showToast(viewController: self, message: message, font: .customFont(.neoMedium, size: 15), color: .mainColor)
+            }
         }
     }
     

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/AuthNumVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/AuthNumVC.swift
@@ -119,6 +119,7 @@ class AuthNumViewController: UIViewController {
         setLayouts()
         authResendButton.setActivatedButton()
         startTimer()
+        addRightSwipe()
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/EmailAuthVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/EmailAuthVC.swift
@@ -188,27 +188,24 @@ class EmailAuthViewController: UIViewController {
         addSubViews()
         setLayouts()
         setTextFieldTarget()
+        setViewTap()
         setLabelTap()
         addRightSwipe()
-        
-        view.addSubview(universityListView)
-        universityListView.snp.makeConstraints { make in
-            make.top.equalTo(schoolLabel.snp.bottom).offset(10)
-            make.left.right.equalToSuperview().inset(28)
-            make.height.equalTo(316)
-        }
-        // 학교 선택 리스트 탭
-        let viewTapGesture = UITapGestureRecognizer(target: self,
-                                                    action: #selector(tapSelectUniv))
-        universitySelectView.isUserInteractionEnabled = true
-        universitySelectView.addGestureRecognizer(viewTapGesture)
-    }
-    
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        view.endEditing(true)
     }
     
     // MARK: - Functions
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        view.endEditing(true)
+        
+        // 학교 선택 리스트뷰가 확장되었을 때, universityListView 밖의 화면을 클릭 시 뷰가 사라지도록 설정함
+        if let touch = touches.first, touch.view != universityListView, touch.view != universitySelectView {
+            isExpanded = false
+            universityListView.isHidden = true
+            toggleImageView.image = UIImage(named: "ToggleMark")
+        }
+    }
     
     private func addSubViews() {
         [
@@ -218,7 +215,8 @@ class EmailAuthViewController: UIViewController {
             universitySelectView,
             emailTextField, emailAddressTextField,
             authSendButton,
-            nextButton
+            nextButton,
+            universityListView  // 맨마지막에 addSubview를 해야 등장 시 맨 앞으로 옴
         ].forEach { view.addSubview($0) }
     }
     
@@ -251,29 +249,34 @@ class EmailAuthViewController: UIViewController {
             make.right.equalTo(remainBar.snp.right).offset(3)
         }
         
-        /* schoolLabel */
+        /* labels */
         schoolLabel.snp.makeConstraints { make in
             make.top.equalTo(progressBar.snp.bottom).offset(50)
             make.left.equalToSuperview().inset(27)
         }
-        /* emailLabel */
         emailLabel.snp.makeConstraints { make in
             make.top.equalTo(schoolLabel.snp.bottom).offset(81)
             make.left.equalToSuperview().inset(27)
         }
         
+        /* universitySelectView */
         universitySelectView.snp.makeConstraints { make in
             make.top.equalTo(schoolLabel.snp.bottom).offset(10)
             make.left.right.equalToSuperview().inset(28)
             make.height.equalTo(41)
         }
+        /* universityListView -> DropDown으로 확장되는 뷰 */
+        universityListView.snp.makeConstraints { make in
+            make.top.equalTo(schoolLabel.snp.bottom).offset(10)
+            make.left.right.equalToSuperview().inset(28)
+            make.height.equalTo(316)
+        }
         
-        /* emailTextField */
+        /* text fields */
         emailTextField.snp.makeConstraints { make in
             make.top.equalTo(emailLabel.snp.bottom).offset(15)
             make.left.equalToSuperview().inset(36)
         }
-        /* emailAddressTextField */
         emailAddressTextField.snp.makeConstraints { make in
             make.top.equalTo(emailTextField.snp.bottom).offset(35)
             make.left.equalToSuperview().inset(36)
@@ -346,6 +349,13 @@ class EmailAuthViewController: UIViewController {
         }
     }
     
+    /* universitySelectView에 탭 제스쳐를 추가 */
+    private func setViewTap() {
+        let viewTapGesture = UITapGestureRecognizer(target: self,
+                                                    action: #selector(tapUnivSelectView))
+        universitySelectView.addGestureRecognizer(viewTapGesture)
+    }
+    
     /* 학교 이름 label에 탭 제스쳐 추가 */
     private func setLabelTap() {
         let labelTapGesture = UITapGestureRecognizer(target: self,
@@ -365,10 +375,11 @@ class EmailAuthViewController: UIViewController {
     }
     
     /* 학교 선택 탭하면 리스트 확장 */
-    @objc private func tapSelectUniv() {
+    @objc private func tapUnivSelectView() {
         // TODO: API 연결 필요
 //        UniversityListViewModel.requestGetUnivList(self)
         isExpanded = !isExpanded
+        
         // 확장하는 거면 리스트 보여주기
         if isExpanded {
             universityListView.isHidden = false

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/EmailAuthVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/EmailAuthVC.swift
@@ -309,8 +309,6 @@ class EmailAuthViewController: UIViewController {
         
         emailAddressTextField = setTextFieldAttrs(msg: "@", width: 187)
         emailAddressTextField.isUserInteractionEnabled = false  // 유저가 입력하는 것이 아니라 학교에 따라 자동 설정되는 것.
-        // TODO: emailAddress -> UILabel로 바뀌어야 할 듯
-        emailAddressTextField.text = "@gachon.ac.kr"   //test
         
         /* buttons attr */
         [authSendButton, nextButton].forEach {
@@ -331,7 +329,9 @@ class EmailAuthViewController: UIViewController {
         return label
     }
     
+    /* 텍스트 필드 속성 설정 */
     private func setTextFieldAttrs(msg: String, width: CGFloat) -> UITextField {
+        // placeHolder 설정
         let textField = UITextField()
         textField.textColor = .black
         textField.attributedPlaceholder = NSAttributedString(
@@ -339,6 +339,7 @@ class EmailAuthViewController: UIViewController {
             attributes: [NSAttributedString.Key.foregroundColor: UIColor.init(hex: 0xD8D8D8),
                          NSAttributedString.Key.font: UIFont.customFont(.neoLight, size: 15)]
         )
+        // 밑에 줄 설정
         textField.makeBottomLine(width)
         return textField
     }
@@ -364,7 +365,8 @@ class EmailAuthViewController: UIViewController {
         univNameLabel.addGestureRecognizer(labelTapGesture)
     }
 
-    @objc private func didChangeTextField(_ sender: UITextField) {
+    @objc
+    private func didChangeTextField(_ sender: UITextField) {
         if emailTextField.text?.count ?? 0 >= 1 && emailAddressTextField.text?.count ?? 0 >= 1 {
             nextButton.setActivatedNextButton()
             authSendButton.setActivatedButton()
@@ -375,7 +377,8 @@ class EmailAuthViewController: UIViewController {
     }
     
     /* 학교 선택 탭하면 리스트 확장 */
-    @objc private func tapUnivSelectView() {
+    @objc
+    private func tapUnivSelectView() {
         // TODO: API 연결 필요
 //        UniversityListViewModel.requestGetUnivList(self)
         isExpanded = !isExpanded
@@ -392,13 +395,19 @@ class EmailAuthViewController: UIViewController {
     }
     
     /* 학교 리스트에서 학교 이름 선택하면 실행 */
-    @objc private func tapUnivName(_ sender: UITapGestureRecognizer) {
+    @objc
+    private func tapUnivName(_ sender: UITapGestureRecognizer) {
         let univName = sender.view as! UILabel
         selectYourUnivLabel.text = univName.text
         selectYourUnivLabel.textColor = .init(hex: 0x636363)
+        
+        // textfield를 가천대의 이메일 address로 채워준다
+        emailAddressTextField.text = tempEmailAddress
+        didChangeTextField(emailAddressTextField)   // 이메일에서 id를 먼저 적고 학교 선택하면 호출 안 되길래 직접 호출
     }
     
-    @objc private func tapAuthSendButton() {
+    @objc
+    private func tapAuthSendButton() {
         if let email = emailTextField.text,
            let emailAddress = emailAddressTextField.text,
            let univ = univNameLabel.text {    // 값이 들어 있어야 괄호 안의 코드 실행 가능
@@ -413,7 +422,8 @@ class EmailAuthViewController: UIViewController {
         }
     }
     
-    @objc private func tapNextButton() {
+    @objc
+    private func tapNextButton() {
         let authNumVC = AuthNumViewController()
         
         authNumVC.modalTransitionStyle = .crossDissolve
@@ -426,6 +436,7 @@ class EmailAuthViewController: UIViewController {
            let nickNameData = self.nickNameData,
            let univ = selectYourUnivLabel.text,
            let email = emailTextField.text,
+           let emailAddress = emailAddressTextField.text,
            let uuid = uuid {
             authNumVC.idData = idData
             authNumVC.pwData = pwData
@@ -434,14 +445,15 @@ class EmailAuthViewController: UIViewController {
             
             // 학교 정보랑 학교 이메일 정보 넘겨줘야 한다 -> 재전송 하기 버튼 때문에
             authNumVC.university = univ
-            // TODO: university name에 맞게 @뒤에 다른 값을 붙여줘야 함
-            authNumVC.email = email + tempEmailAddress
+            // TODO: university name에 맞게 @뒤에 다른 값을 붙여줘야 함 - 일단은 가천대만
+            authNumVC.email = email + emailAddress
+            print(email + emailAddress)
             
             // PhoneAuthVC까지 가지고 가야 한다.
             authNumVC.uuid = uuid
+            
+            present(authNumVC, animated: true)
         }
-        
-        present(authNumVC, animated: true)
     }
     
 }

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/EmailAuthVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/EmailAuthVC.swift
@@ -368,7 +368,6 @@ class EmailAuthViewController: UIViewController {
     @objc
     private func didChangeTextField(_ sender: UITextField) {
         if emailTextField.text?.count ?? 0 >= 1 && emailAddressTextField.text?.count ?? 0 >= 1 {
-            nextButton.setActivatedNextButton()
             authSendButton.setActivatedButton()
         } else {
             nextButton.setDeactivatedNextButton()
@@ -418,7 +417,14 @@ class EmailAuthViewController: UIViewController {
             let input = EmailAuthInput(email: email+emailAddress, university: univ, uuid: uuid.uuidString)
             print("DEBUG: ", uuid.uuidString)
             // 이메일로 인증번호 전송하는 API 호출
-            EmailAuthViewModel.requestSendEmail(self, input)
+            EmailAuthViewModel.requestSendEmail(input) { isSuccess, message in// // 경우에 맞는 토스트 메세지 출력
+                self.showToast(viewController: self, message: message, font: .customFont(.neoMedium, size: 15), color: .mainColor)
+                
+                // 이메일 인증번호 전송까지 성공했을 때에 다음 버튼을 활성화
+                if isSuccess {
+                    self.nextButton.setActivatedNextButton()
+                }
+            }
         }
     }
     

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/EmailAuthVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/EmailAuthVC.swift
@@ -189,6 +189,7 @@ class EmailAuthViewController: UIViewController {
         setLayouts()
         setTextFieldTarget()
         setLabelTap()
+        addRightSwipe()
         
         view.addSubview(universityListView)
         universityListView.snp.makeConstraints { make in

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/NaverRegisterVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/NaverRegisterVC.swift
@@ -205,6 +205,7 @@ class NaverRegisterViewController: UIViewController {
     // MARK: - Properties
     
     var isNicknameChecked = false
+    var isEmailSended = false
     var isExpanded: Bool! = false
     let tempEmailAddress = "@gachon.ac.kr"
     
@@ -440,8 +441,11 @@ class NaverRegisterViewController: UIViewController {
     
     @objc
     private func didChangeTextField(_ sender: UITextField) {
+        // 초기화
         if sender == nickNameTextField {
             isNicknameChecked = false
+        } else if sender == emailTextField {
+            isEmailSended = false
         }
         
         if nickNameTextField.text?.count ?? 0 >= 1 {
@@ -457,6 +461,7 @@ class NaverRegisterViewController: UIViewController {
         }
 
         if isNicknameChecked
+            && isEmailSended
             && selectYourUnivLabel.text != "자신의 학교를 선택해주세요"
             && emailTextField.text?.count ?? 0 >= 1
         {
@@ -505,7 +510,15 @@ class NaverRegisterViewController: UIViewController {
             let input = EmailAuthInput(email: email+emailAddress, university: univ, uuid: uuid.uuidString)
             print("DEBUG: ", uuid.uuidString)
             // 이메일로 인증번호 전송하는 API 호출
-            EmailAuthViewModel.requestSendEmail(self, input)
+            EmailAuthViewModel.requestSendEmail(input) { isSuccess, message in// // 경우에 맞는 토스트 메세지 출력
+                self.showToast(viewController: self, message: message, font: .customFont(.neoMedium, size: 15), color: .mainColor)
+                
+                // 닉네임 확인, 이메일 인증번호 전송까지 성공했을 때에 다음 버튼을 활성화
+                if isSuccess, self.isNicknameChecked {
+                    self.nextButton.setActivatedNextButton()
+                    self.isEmailSended = isSuccess
+                }
+            }
         }
     }
     

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/NaverRegisterVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/NaverRegisterVC.swift
@@ -225,6 +225,7 @@ class NaverRegisterViewController: UIViewController {
         setLabelTap()
         addSubViews()
         setLayouts()
+        addRightSwipe()
     }
     
     // MARK: - Functions

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/NaverRegisterVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/NaverRegisterVC.swift
@@ -219,10 +219,11 @@ class NaverRegisterViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .white
         
-        setUniversitySelectView()
         setAttributes()
         setTextFieldTarget()
+        setViewTap()
         setLabelTap()
+        
         addSubViews()
         setLayouts()
         addRightSwipe()
@@ -231,18 +232,27 @@ class NaverRegisterViewController: UIViewController {
     // MARK: - Functions
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
         view.endEditing(true)
+        
+        // 학교 선택 리스트뷰가 확장되었을 때, universityListView 밖의 화면을 클릭 시 뷰가 사라지도록 설정함
+        if let touch = touches.first, touch.view != universityListView, touch.view != universitySelectView {
+            isExpanded = false
+            universityListView.isHidden = true
+            toggleImageView.image = UIImage(named: "ToggleMark")
+        }
     }
     
     private func addSubViews() {
-        [progressBar, remainBar, progressIcon, remainIcon,
-        nickNameLabel, schoolLabel, emailLabel,
-        nickNameTextField, emailTextField, emailAddressTextField,
-        universityListView, universitySelectView,
-        nickNameAvailableLabel,
-         nickNameCheckButton, authSendButton, nextButton].forEach {
-            view.addSubview($0)
-        }
+        [
+            progressBar, remainBar, progressIcon, remainIcon,
+            nickNameLabel, nickNameAvailableLabel, schoolLabel, emailLabel,
+            nickNameTextField, emailTextField, emailAddressTextField,
+            universitySelectView,
+            nickNameCheckButton, authSendButton,
+            nextButton,
+            universityListView  // 맨마지막에 addSubview를 해야 등장 시 맨 앞으로 옴
+        ].forEach { view.addSubview($0) }
     }
     
     private func setLayouts() {
@@ -307,16 +317,16 @@ class NaverRegisterViewController: UIViewController {
             make.top.equalTo(emailTextField.snp.bottom).offset(35)
         }
         
-        universityListView.snp.makeConstraints { make in
-            make.top.equalTo(schoolLabel.snp.bottom).offset(10)
-            make.left.right.equalToSuperview().inset(28)
-            make.height.equalTo(316)
-        }
-        
+        /* select univ */
         universitySelectView.snp.makeConstraints { make in
             make.top.equalTo(schoolLabel.snp.bottom).offset(10)
             make.left.right.equalToSuperview().inset(28)
             make.height.equalTo(41)
+        }
+        universityListView.snp.makeConstraints { make in
+            make.top.equalTo(schoolLabel.snp.bottom).offset(10)
+            make.left.right.equalToSuperview().inset(28)
+            make.height.equalTo(316)
         }
         
         /* nickNameAvailableLabel */
@@ -348,12 +358,6 @@ class NaverRegisterViewController: UIViewController {
             make.width.equalTo(105)
             make.height.equalTo(41)
         }
-    }
-    
-    private func setUniversitySelectView() {
-        let viewTapGesture = UITapGestureRecognizer(target: self,
-                                                    action: #selector(tapSelectUniv))
-        universitySelectView.addGestureRecognizer(viewTapGesture)
     }
     
     private func setAttributes() {
@@ -398,6 +402,13 @@ class NaverRegisterViewController: UIViewController {
         [nickNameTextField, emailTextField, emailAddressTextField].forEach { textField in
             textField.addTarget(self, action: #selector(didChangeTextField(_:)), for: .editingChanged)
         }
+    }
+    
+    /* universitySelectView에 탭 제스쳐를 추가 */
+    private func setViewTap() {
+        let viewTapGesture = UITapGestureRecognizer(target: self,
+                                                    action: #selector(tapUnivSelectView))
+        universitySelectView.addGestureRecognizer(viewTapGesture)
     }
     
     private func setLabelTap() {
@@ -463,7 +474,7 @@ class NaverRegisterViewController: UIViewController {
         }
     }
     
-    @objc private func tapSelectUniv() {
+    @objc private func tapUnivSelectView() {
         // TODO: API 연결 필요
 //        UniversityListViewModel.requestGetUnivList(self)
         isExpanded = !isExpanded

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/NaverRegisterVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/NaverRegisterVC.swift
@@ -203,8 +203,10 @@ class NaverRegisterViewController: UIViewController {
     }()
     
     // MARK: - Properties
+    
     var isNicknameChecked = false
     var isExpanded: Bool! = false
+    let tempEmailAddress = "@gachon.ac.kr"
     
     /* 회원가입 정보 */
     // 밑에 건 이 화면에서 바로 생성하여 전달 -> 변수로 둘 필요 x
@@ -373,9 +375,8 @@ class NaverRegisterViewController: UIViewController {
         emailTextField = setTextFieldAttrs(msg: "입력하세요", width: 307)
         emailTextField.autocapitalizationType = .none
         
-        emailAddressTextField = setTextFieldAttrs(msg: "@gachon.ac.kr", width: 187)
+        emailAddressTextField = setTextFieldAttrs(msg: "@", width: 187)
         emailAddressTextField.isUserInteractionEnabled = false
-        emailAddressTextField.text = "@gachon.ac.kr"
     }
     
     private func setMainLabelAttrs(_ text: String) -> UILabel {
@@ -386,7 +387,9 @@ class NaverRegisterViewController: UIViewController {
         return label
     }
     
+    /* 텍스트 필드 속성 설정 */
     private func setTextFieldAttrs(msg: String, width: CGFloat) -> UITextField {
+        // placeHolder 설정
         let textField = UITextField()
         textField.textColor = .black
         textField.attributedPlaceholder = NSAttributedString(
@@ -394,6 +397,7 @@ class NaverRegisterViewController: UIViewController {
             attributes: [NSAttributedString.Key.foregroundColor: UIColor.init(hex: 0xD8D8D8),
                          NSAttributedString.Key.font: UIFont.customFont(.neoLight, size: 15)]
         )
+        // 밑에 줄 설정
         textField.makeBottomLine(width)
         return textField
     }
@@ -418,7 +422,10 @@ class NaverRegisterViewController: UIViewController {
         univNameLabel.addGestureRecognizer(labelTapGesture)
     }
     
-    @objc private func tapNickNameCheckButton() {
+    // MARK: - @objc Functions
+    
+    @objc
+    private func tapNickNameCheckButton() {
         if nickNameTextField.text?.isValidNickname() ?? false == false {
             nickNameAvailableLabel.text = "3-8자 영문 혹은 한글로 입력"
             nickNameAvailableLabel.textColor = .red
@@ -431,23 +438,8 @@ class NaverRegisterViewController: UIViewController {
         }
     }
     
-    // AuthNumVC로 화면 전환 -> 이메일 인증번호 확인하는 화면으로 전환한 것
-    @objc private func showNextView() {
-        let authNumVC = AuthNumViewController()
-        
-        authNumVC.modalTransitionStyle = .crossDissolve
-        authNumVC.modalPresentationStyle = .fullScreen
-        
-        authNumVC.isFromNaverRegister = true
-        authNumVC.accessToken = accessToken
-        authNumVC.nickNameData = nickNameTextField.text
-        authNumVC.university = selectYourUnivLabel.text
-        authNumVC.email = "\(emailTextField.text!)" + "\(emailAddressTextField.text!)"
-        
-        present(authNumVC, animated: true)
-    }
-    
-    @objc private func didChangeTextField(_ sender: UITextField) {
+    @objc
+    private func didChangeTextField(_ sender: UITextField) {
         if sender == nickNameTextField {
             isNicknameChecked = false
         }
@@ -474,7 +466,8 @@ class NaverRegisterViewController: UIViewController {
         }
     }
     
-    @objc private func tapUnivSelectView() {
+    @objc
+    private func tapUnivSelectView() {
         // TODO: API 연결 필요
 //        UniversityListViewModel.requestGetUnivList(self)
         isExpanded = !isExpanded
@@ -489,13 +482,19 @@ class NaverRegisterViewController: UIViewController {
         self.view.bringSubviewToFront(universitySelectView)
     }
     
-    @objc private func tapUnivName(_ sender: UITapGestureRecognizer) {
+    @objc
+    private func tapUnivName(_ sender: UITapGestureRecognizer) {
         let univName = sender.view as! UILabel
         selectYourUnivLabel.text = univName.text
         selectYourUnivLabel.textColor = .init(hex: 0x636363)
+        
+        // textfield를 가천대의 이메일 address로 채워준다
+        emailAddressTextField.text = tempEmailAddress
+        didChangeTextField(emailAddressTextField)   // 이메일에서 id를 먼저 적고 학교 선택하면 호출 안 되길래 직접 호출
     }
     
-    @objc private func tapAuthSendButton() {
+    @objc
+    private func tapAuthSendButton() {
         if let email = emailTextField.text,
            let emailAddress = emailAddressTextField.text,
            let univ = univNameLabel.text {    // 값이 들어 있어야 괄호 안의 코드 실행 가능
@@ -507,6 +506,32 @@ class NaverRegisterViewController: UIViewController {
             print("DEBUG: ", uuid.uuidString)
             // 이메일로 인증번호 전송하는 API 호출
             EmailAuthViewModel.requestSendEmail(self, input)
+        }
+    }
+    
+    // AuthNumVC로 화면 전환 -> 이메일 인증번호 확인하는 화면으로 전환한 것
+    @objc
+    private func showNextView() {
+        let authNumVC = AuthNumViewController()
+        
+        authNumVC.modalTransitionStyle = .crossDissolve
+        authNumVC.modalPresentationStyle = .fullScreen
+        
+        // 데이터 전달
+        if let accessToken = accessToken,
+           let nickNameData = nickNameTextField.text,
+           let university = selectYourUnivLabel.text,
+           let emailId = emailTextField.text,
+           let emailAddress = emailAddressTextField.text {
+            /* 값이 존재할 때에만 데이터 전달을 해야 한다 */
+            authNumVC.isFromNaverRegister = true
+            authNumVC.accessToken = accessToken
+            authNumVC.nickNameData = nickNameData
+            authNumVC.university = university
+            authNumVC.email = emailId + emailAddress
+            
+            // 화면 전환
+            present(authNumVC, animated: true)
         }
     }
 }

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/PhoneAuthVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/PhoneAuthVC.swift
@@ -229,6 +229,7 @@ class PhoneAuthViewController: UIViewController {
         setTextFieldTarget()
         addSubViews()
         setLayouts()
+        addRightSwipe()
     }
     
     // MARK: - Functions

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/PhoneAuthVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/PhoneAuthVC.swift
@@ -440,9 +440,9 @@ class PhoneAuthViewController: UIViewController {
             agreementVC.university = univ
             agreementVC.emailId = emailId
             agreementVC.phoneNumberId = phoneNumberId
+            
+            present(agreementVC, animated: true)
         }
-        
-        present(agreementVC, animated: true)
     }
     
     /* 핸드폰번호 인증번호 전송 버튼 눌렀을 때 실행되는 함수 */

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/RegisterVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/RegisterVC.swift
@@ -132,7 +132,7 @@ class RegisterViewController: UIViewController {
         addSubViews()
         setLayouts()
         setTextFieldTarget()
-//        addRightSwipe()
+        addRightSwipe()
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -323,7 +323,7 @@ class RegisterViewController: UIViewController {
     @objc private func showNextView() {
         let emailAuthVC = EmailAuthViewController()
         
-        emailAuthVC.modalTransitionStyle = .coverVertical
+        emailAuthVC.modalTransitionStyle = .crossDissolve
         emailAuthVC.modalPresentationStyle = .fullScreen
         
         // 데이터 전달

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/RegisterVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/RegisterVC.swift
@@ -335,9 +335,9 @@ class RegisterViewController: UIViewController {
             emailAuthVC.pwData = pwData
             emailAuthVC.pwCheckData = pwCheckData
             emailAuthVC.nickNameData = nickNameData
+            
+            present(emailAuthVC, animated: true)
         }
-        
-        present(emailAuthVC, animated: true)
     }
     
     @objc private func didChangeTextField(_ sender: UITextField) {

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Report/ReportDetailEtcVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Report/ReportDetailEtcVC.swift
@@ -95,6 +95,212 @@ class ReportDetailEtcViewController: UIViewController {
         return button
     }()
     
+    // 배경에 뜰 어두운 블러뷰
+    var visualEffectView: UIVisualEffectView?
+    
+    /* 신고하기 성공 시 나오는 신고성공 안내 뷰 */
+    lazy var reportSuccessView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 7
+        view.snp.makeConstraints { make in
+            make.width.equalTo(256)
+            make.height.equalTo(226)
+        }
+        
+        /* top View */
+        let topSubView = UIView()
+        topSubView.backgroundColor = UIColor(hex: 0xF8F8F8)
+        view.addSubview(topSubView)
+        topSubView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.width.equalToSuperview()
+            make.height.equalTo(50)
+        }
+        
+        /* set titleLabel */
+        let titleLabel = UILabel()
+        titleLabel.text = "신고하기"
+        titleLabel.textColor = UIColor(hex: 0xA8A8A8)
+        titleLabel.font = .customFont(.neoMedium, size: 14)
+        topSubView.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+        
+        /* set cancelButton */
+        lazy var cancelButton = UIButton()
+        cancelButton.setImage(UIImage(named: "Xmark"), for: .normal)
+        cancelButton.addTarget(self, action: #selector(removeView(sender:)), for: .touchUpInside)
+        topSubView.addSubview(cancelButton)
+        cancelButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.width.equalTo(20)
+            make.height.equalTo(12)
+            make.right.equalToSuperview().offset(-15)
+        }
+        
+        /* bottom View: contents, 확인 버튼 */
+        let bottomSubView = UIView()
+        bottomSubView.backgroundColor = UIColor.white
+        view.addSubview(bottomSubView)
+        bottomSubView.snp.makeConstraints { make in
+            make.top.equalTo(topSubView.snp.bottom)
+            make.width.equalToSuperview()
+            make.height.equalTo(176)
+        }
+        
+        let contentLabel = UILabel()
+        let lineView = UIView()
+        lazy var confirmButton = UIButton()
+        
+        [contentLabel, lineView, confirmButton].forEach {
+            bottomSubView.addSubview($0)
+        }
+        
+        /* set contentLabel */
+        contentLabel.text = "고객님께서 요청하신 사항에\n따른 신고가 정상적으로\n처리되었습니다."
+        contentLabel.numberOfLines = 0
+        contentLabel.textColor = .init(hex: 0x2F2F2F)
+        contentLabel.font = .customFont(.neoMedium, size: 14)
+        let attrString = NSMutableAttributedString(string: contentLabel.text!)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 6
+        paragraphStyle.alignment = .center
+        attrString.addAttribute(NSAttributedString.Key.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attrString.length))
+        contentLabel.attributedText = attrString
+        contentLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().inset(20)
+        }
+        
+        /* set lineView */
+        lineView.backgroundColor = UIColor(hex: 0xEFEFEF)
+        lineView.snp.makeConstraints { make in
+            make.top.equalTo(contentLabel.snp.bottom).offset(15)
+            make.left.equalTo(18)
+            make.right.equalTo(-18)
+            make.height.equalTo(1.7)
+        }
+        
+        /* set confirmButton */
+        confirmButton.setTitleColor(.mainColor, for: .normal)
+        confirmButton.setTitle("확인", for: .normal)
+        confirmButton.titleLabel?.font = .customFont(.neoBold, size: 18)
+        confirmButton.addTarget(self, action: #selector(removeView(sender:)), for: .touchUpInside)
+        confirmButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(lineView.snp.bottom).offset(18)
+            make.width.height.equalTo(34)
+        }
+        
+        return view
+    }()
+    
+    /* 신고실패 안내뷰의 contents label */
+    var failContentLabel = UILabel()
+    
+    /* 신고하기 실패 시 나오는 신고실패 안내 뷰 */
+    lazy var reportFailView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 7
+        view.snp.makeConstraints { make in
+            make.width.equalTo(256)
+            make.height.equalTo(203)
+        }
+        
+        /* top View */
+        let topSubView = UIView()
+        topSubView.backgroundColor = UIColor(hex: 0xF8F8F8)
+        view.addSubview(topSubView)
+        topSubView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.width.equalToSuperview()
+            make.height.equalTo(50)
+        }
+        
+        /* set titleLabel */
+        let titleLabel = UILabel()
+        titleLabel.text = "신고하기"
+        titleLabel.textColor = UIColor(hex: 0xA8A8A8)
+        titleLabel.font = .customFont(.neoMedium, size: 14)
+        topSubView.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+        
+        /* set cancelButton */
+        lazy var cancelButton = UIButton()
+        cancelButton.setImage(UIImage(named: "Xmark"), for: .normal)
+        cancelButton.addTarget(self, action: #selector(removeView(sender:)), for: .touchUpInside)
+        topSubView.addSubview(cancelButton)
+        cancelButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.width.equalTo(20)
+            make.height.equalTo(12)
+            make.right.equalToSuperview().offset(-15)
+        }
+        
+        /* bottom View: contents, 확인 버튼 */
+        let bottomSubView = UIView()
+        bottomSubView.backgroundColor = UIColor.white
+        view.addSubview(bottomSubView)
+        bottomSubView.snp.makeConstraints { make in
+            make.top.equalTo(topSubView.snp.bottom)
+            make.width.equalToSuperview()
+            make.height.equalTo(153)
+        }
+        
+        let lineView = UIView()
+        lazy var confirmButton = UIButton()
+        
+        [failContentLabel, lineView, confirmButton].forEach {
+            bottomSubView.addSubview($0)
+        }
+        
+        /* set failContentLabel */
+        failContentLabel.numberOfLines = 0
+        failContentLabel.textColor = .init(hex: 0x2F2F2F)
+        failContentLabel.font = .customFont(.neoMedium, size: 14)
+        let attrString = NSMutableAttributedString(string: failContentLabel.text!)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 6
+        paragraphStyle.alignment = .center
+        attrString.addAttribute(NSAttributedString.Key.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attrString.length))
+        failContentLabel.attributedText = attrString
+        failContentLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().inset(20)
+            make.width.equalTo(190)
+            make.height.equalTo(48)
+        }
+        
+        /* set lineView */
+        lineView.backgroundColor = UIColor(hex: 0xEFEFEF)
+        lineView.snp.makeConstraints { make in
+            make.top.equalTo(failContentLabel.snp.bottom).offset(15)
+            make.left.equalTo(18)
+            make.right.equalTo(-18)
+            make.height.equalTo(1.7)
+        }
+        
+        /* set confirmButton */
+        confirmButton.setTitleColor(.mainColor, for: .normal)
+        confirmButton.setTitle("확인", for: .normal)
+        confirmButton.titleLabel?.font = .customFont(.neoBold, size: 18)
+        confirmButton.addTarget(self, action: #selector(removeView(sender:)), for: .touchUpInside)
+        confirmButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(lineView.snp.bottom).offset(18)
+            make.width.height.equalTo(34)
+        }
+        
+        return view
+    }()
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -192,6 +398,24 @@ class ReportDetailEtcViewController: UIViewController {
         }
     }
     
+    /* 신고하기 완료 안내 뷰 보여주는 함수 */
+    private func showReportSuccessView() {
+        view.addSubview(reportSuccessView)
+        reportSuccessView.snp.makeConstraints { make in
+            make.centerX.centerY.equalToSuperview()
+        }
+    }
+    
+    /* 신고하기 실패 안내 뷰 보여주는 함수 */
+    private func showReportFailView(_ message: String) {
+        failContentLabel.text = message
+        
+        view.addSubview(reportFailView)
+        reportFailView.snp.makeConstraints { make in
+            make.centerX.centerY.equalToSuperview()
+        }
+    }
+    
     // MARK: - Objc Functions
 
     /* 키보드 숨기기 */
@@ -235,7 +459,7 @@ class ReportDetailEtcViewController: UIViewController {
         self.reportButton.transform = .identity
     }
     
-    /* 하단의 신고하기 버튼을 눌렀을 때 실행되는 함수 -> 신고 제출, 신고하기 토스트 메세지 */
+    /* 하단의 신고하기 버튼을 눌렀을 때 실행되는 함수 -> 신고 제출, 신고하기 성패 안내 */
     @objc
     private func tapReportButton() {
         guard let reportCategoryId = reportCategoryId else { return }
@@ -244,19 +468,47 @@ class ReportDetailEtcViewController: UIViewController {
         // 파티 게시글 신고일 때
         if reportCategoryId < 5 {
             let input = ReportPartyInput(block: isBlock, reportCategoryId: self.reportCategoryId, reportContent: reportTextView.text, reportedDeliveryPartyId: partyId, reportedMemberId: memberId)
-            ReportAPI.requestReportParty(self, input) {
-                // 성공했으면 이전 뷰로 돌아가게
-                self.navigationController?.popViewController(animated: true)
+            ReportAPI.requestReportParty(input) { isSuccess, resultMessage in
+                // 블러뷰 세팅
+                self.visualEffectView = self.setDarkBlurView()
+                
+                if isSuccess {
+                    // 성공했으면 성공안내 뷰 띄워주기
+                    self.showReportSuccessView()
+                } else {
+                    // 성공했으면 실패안내 뷰 띄워주기
+                    guard let resultMessage = resultMessage else { return }
+                    self.showReportFailView(resultMessage)
+                }
             }
         } else {    // 사용자 신고일 때
             let input = ReportMemberInput(block: isBlock, reportCategoryId: self.reportCategoryId, reportContent: reportTextView.text, reportedMemberId: memberId)
-            ReportAPI.requestReportMember(self, input) {
-                // 성공했으면 이전 뷰로 돌아가게
-                self.navigationController?.popViewController(animated: true)
+            ReportAPI.requestReportMember(input) { isSuccess, resultMessage in
+                // 블러뷰 세팅
+                self.visualEffectView = self.setDarkBlurView()
+                
+                if isSuccess {
+                    // 성공했으면 성공안내 뷰 띄워주기
+                    self.showReportSuccessView()
+                } else {
+                    // 성공했으면 실패안내 뷰 띄워주기
+                    guard let resultMessage = resultMessage else { return }
+                    self.showReportFailView(resultMessage)
+                }
             }
         }
     }
-
+    
+    /* 신고하기 완료/실패 안내 뷰에서 X버튼이나 확인버튼을 눌렀을 때 실행되는 함수 */
+    @objc
+    private func removeView(sender: UIButton) {
+        guard let view = sender.superview else { return }
+        view.removeFromSuperview()
+        visualEffectView?.removeFromSuperview()
+        
+        // 안내뷰랑 블러뷰 제거하고 이전 화면으로 이동
+        self.navigationController?.popViewController(animated: true)
+    }
 }
 
 // MARK: - UITextViewDelegate

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Report/ReportDetailVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Report/ReportDetailVC.swift
@@ -29,7 +29,7 @@ class ReportDetailViewController: UIViewController {
         return label
     }()
     
-    let textViewPlaceHolder = "(선택) 어떤 상황인가요?"
+    let textViewPlaceHolder = "(선택) 어떤 상황인가요? 긱사생에게 알려주시면 문제 해결에 도움이 됩니다"
     lazy var reportTextView: UITextView = {
         let textView = UITextView()
         textView.backgroundColor = .white
@@ -92,6 +92,212 @@ class ReportDetailViewController: UIViewController {
         }
         
         return button
+    }()
+    
+    // 배경에 뜰 어두운 블러뷰
+    var visualEffectView: UIVisualEffectView?
+    
+    /* 신고하기 성공 시 나오는 신고성공 안내 뷰 */
+    lazy var reportSuccessView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 7
+        view.snp.makeConstraints { make in
+            make.width.equalTo(256)
+            make.height.equalTo(226)
+        }
+        
+        /* top View */
+        let topSubView = UIView()
+        topSubView.backgroundColor = UIColor(hex: 0xF8F8F8)
+        view.addSubview(topSubView)
+        topSubView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.width.equalToSuperview()
+            make.height.equalTo(50)
+        }
+        
+        /* set titleLabel */
+        let titleLabel = UILabel()
+        titleLabel.text = "신고하기"
+        titleLabel.textColor = UIColor(hex: 0xA8A8A8)
+        titleLabel.font = .customFont(.neoMedium, size: 14)
+        topSubView.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+        
+        /* set cancelButton */
+        lazy var cancelButton = UIButton()
+        cancelButton.setImage(UIImage(named: "Xmark"), for: .normal)
+        cancelButton.addTarget(self, action: #selector(removeView(sender:)), for: .touchUpInside)
+        topSubView.addSubview(cancelButton)
+        cancelButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.width.equalTo(20)
+            make.height.equalTo(12)
+            make.right.equalToSuperview().offset(-15)
+        }
+        
+        /* bottom View: contents, 확인 버튼 */
+        let bottomSubView = UIView()
+        bottomSubView.backgroundColor = UIColor.white
+        view.addSubview(bottomSubView)
+        bottomSubView.snp.makeConstraints { make in
+            make.top.equalTo(topSubView.snp.bottom)
+            make.width.equalToSuperview()
+            make.height.equalTo(176)
+        }
+        
+        let contentLabel = UILabel()
+        let lineView = UIView()
+        lazy var confirmButton = UIButton()
+        
+        [contentLabel, lineView, confirmButton].forEach {
+            bottomSubView.addSubview($0)
+        }
+        
+        /* set contentLabel */
+        contentLabel.text = "고객님께서 요청하신 사항에\n따른 신고가 정상적으로\n처리되었습니다."
+        contentLabel.numberOfLines = 0
+        contentLabel.textColor = .init(hex: 0x2F2F2F)
+        contentLabel.font = .customFont(.neoMedium, size: 14)
+        let attrString = NSMutableAttributedString(string: contentLabel.text!)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 6
+        paragraphStyle.alignment = .center
+        attrString.addAttribute(NSAttributedString.Key.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attrString.length))
+        contentLabel.attributedText = attrString
+        contentLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().inset(20)
+        }
+        
+        /* set lineView */
+        lineView.backgroundColor = UIColor(hex: 0xEFEFEF)
+        lineView.snp.makeConstraints { make in
+            make.top.equalTo(contentLabel.snp.bottom).offset(15)
+            make.left.equalTo(18)
+            make.right.equalTo(-18)
+            make.height.equalTo(1.7)
+        }
+        
+        /* set confirmButton */
+        confirmButton.setTitleColor(.mainColor, for: .normal)
+        confirmButton.setTitle("확인", for: .normal)
+        confirmButton.titleLabel?.font = .customFont(.neoBold, size: 18)
+        confirmButton.addTarget(self, action: #selector(removeView(sender:)), for: .touchUpInside)
+        confirmButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(lineView.snp.bottom).offset(18)
+            make.width.height.equalTo(34)
+        }
+        
+        return view
+    }()
+    
+    /* 신고실패 안내뷰의 contents label */
+    var failContentLabel = UILabel()
+    
+    /* 신고하기 실패 시 나오는 신고실패 안내 뷰 */
+    lazy var reportFailView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 7
+        view.snp.makeConstraints { make in
+            make.width.equalTo(256)
+            make.height.equalTo(203)
+        }
+        
+        /* top View */
+        let topSubView = UIView()
+        topSubView.backgroundColor = UIColor(hex: 0xF8F8F8)
+        view.addSubview(topSubView)
+        topSubView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.width.equalToSuperview()
+            make.height.equalTo(50)
+        }
+        
+        /* set titleLabel */
+        let titleLabel = UILabel()
+        titleLabel.text = "신고하기"
+        titleLabel.textColor = UIColor(hex: 0xA8A8A8)
+        titleLabel.font = .customFont(.neoMedium, size: 14)
+        topSubView.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+        
+        /* set cancelButton */
+        lazy var cancelButton = UIButton()
+        cancelButton.setImage(UIImage(named: "Xmark"), for: .normal)
+        cancelButton.addTarget(self, action: #selector(removeView(sender:)), for: .touchUpInside)
+        topSubView.addSubview(cancelButton)
+        cancelButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.width.equalTo(20)
+            make.height.equalTo(12)
+            make.right.equalToSuperview().offset(-15)
+        }
+        
+        /* bottom View: contents, 확인 버튼 */
+        let bottomSubView = UIView()
+        bottomSubView.backgroundColor = UIColor.white
+        view.addSubview(bottomSubView)
+        bottomSubView.snp.makeConstraints { make in
+            make.top.equalTo(topSubView.snp.bottom)
+            make.width.equalToSuperview()
+            make.height.equalTo(153)
+        }
+        
+        let lineView = UIView()
+        lazy var confirmButton = UIButton()
+        
+        [failContentLabel, lineView, confirmButton].forEach {
+            bottomSubView.addSubview($0)
+        }
+        
+        /* set failContentLabel */
+        failContentLabel.numberOfLines = 0
+        failContentLabel.textColor = .init(hex: 0x2F2F2F)
+        failContentLabel.font = .customFont(.neoMedium, size: 14)
+        let attrString = NSMutableAttributedString(string: failContentLabel.text!)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 6
+        paragraphStyle.alignment = .center
+        attrString.addAttribute(NSAttributedString.Key.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attrString.length))
+        failContentLabel.attributedText = attrString
+        failContentLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().inset(20)
+            make.width.equalTo(190)
+            make.height.equalTo(48)
+        }
+        
+        /* set lineView */
+        lineView.backgroundColor = UIColor(hex: 0xEFEFEF)
+        lineView.snp.makeConstraints { make in
+            make.top.equalTo(failContentLabel.snp.bottom).offset(15)
+            make.left.equalTo(18)
+            make.right.equalTo(-18)
+            make.height.equalTo(1.7)
+        }
+        
+        /* set confirmButton */
+        confirmButton.setTitleColor(.mainColor, for: .normal)
+        confirmButton.setTitle("확인", for: .normal)
+        confirmButton.titleLabel?.font = .customFont(.neoBold, size: 18)
+        confirmButton.addTarget(self, action: #selector(removeView(sender:)), for: .touchUpInside)
+        confirmButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(lineView.snp.bottom).offset(18)
+            make.width.height.equalTo(34)
+        }
+        
+        return view
     }()
     
     // MARK: - Life Cycle
@@ -192,6 +398,24 @@ class ReportDetailViewController: UIViewController {
         }
     }
     
+    /* 신고하기 완료 안내 뷰 보여주는 함수 */
+    private func showReportSuccessView() {
+        view.addSubview(reportSuccessView)
+        reportSuccessView.snp.makeConstraints { make in
+            make.centerX.centerY.equalToSuperview()
+        }
+    }
+    
+    /* 신고하기 실패 안내 뷰 보여주는 함수 */
+    private func showReportFailView(_ message: String) {
+        failContentLabel.text = message
+        
+        view.addSubview(reportFailView)
+        reportFailView.snp.makeConstraints { make in
+            make.centerX.centerY.equalToSuperview()
+        }
+    }
+    
     // MARK: - Objc Functions
 
     /* 키보드 숨기기 */
@@ -235,7 +459,7 @@ class ReportDetailViewController: UIViewController {
         self.reportButton.transform = .identity
     }
     
-    /* 하단의 신고하기 버튼을 눌렀을 때 실행되는 함수 -> 신고 제출, 신고하기 토스트 메세지 */
+    /* 하단의 신고하기 버튼을 눌렀을 때 실행되는 함수 -> 신고 제출, 신고하기 성패 안내 */
     @objc
     private func tapReportButton() {
         guard let reportCategoryId = reportCategoryId else { return }
@@ -244,19 +468,47 @@ class ReportDetailViewController: UIViewController {
         // 파티 게시글 신고일 때
         if reportCategoryId < 5 {
             let input = ReportPartyInput(block: isBlock, reportCategoryId: self.reportCategoryId, reportContent: reportTextView.text, reportedDeliveryPartyId: partyId, reportedMemberId: memberId)
-            ReportAPI.requestReportParty(self, input) {
-                // 성공했으면 이전 뷰로 돌아가게
-                self.navigationController?.popViewController(animated: true)
+            ReportAPI.requestReportParty(input) { isSuccess, resultMessage in
+                // 블러뷰 세팅
+                self.visualEffectView = self.setDarkBlurView()
+                
+                if isSuccess {
+                    // 성공했으면 성공안내 뷰 띄워주기
+                    self.showReportSuccessView()
+                } else {
+                    // 성공했으면 실패안내 뷰 띄워주기
+                    guard let resultMessage = resultMessage else { return }
+                    self.showReportFailView(resultMessage)
+                }
             }
         } else {    // 사용자 신고일 때
             let input = ReportMemberInput(block: isBlock, reportCategoryId: self.reportCategoryId, reportContent: reportTextView.text, reportedMemberId: memberId)
-            ReportAPI.requestReportMember(self, input) {
-                // 성공했으면 이전 뷰로 돌아가게
-                self.navigationController?.popViewController(animated: true)
+            ReportAPI.requestReportMember(input) { isSuccess, resultMessage in
+                // 블러뷰 세팅
+                self.visualEffectView = self.setDarkBlurView()
+                
+                if isSuccess {
+                    // 성공했으면 성공안내 뷰 띄워주기
+                    self.showReportSuccessView()
+                } else {
+                    // 성공했으면 실패안내 뷰 띄워주기
+                    guard let resultMessage = resultMessage else { return }
+                    self.showReportFailView(resultMessage)
+                }
             }
         }
     }
-
+    
+    /* 신고하기 완료/실패 안내 뷰에서 X버튼이나 확인버튼을 눌렀을 때 실행되는 함수 */
+    @objc
+    private func removeView(sender: UIButton) {
+        guard let view = sender.superview else { return }
+        view.removeFromSuperview()
+        visualEffectView?.removeFromSuperview()
+        
+        // 안내뷰랑 블러뷰 제거하고 이전 화면으로 이동
+        self.navigationController?.popViewController(animated: true)
+    }
 }
 
 // MARK: - UITextViewDelegate

--- a/Geeksasaeng/Geeksasaeng/ViewModel/Register/EmailAuthViewModel.swift
+++ b/Geeksasaeng/Geeksasaeng/ViewModel/Register/EmailAuthViewModel.swift
@@ -11,7 +11,7 @@ import Alamofire
 // 이메일로 인증번호 전송하는 API 연동
 class EmailAuthViewModel {
     
-    public static func requestSendEmail(_ viewController : UIViewController, _ parameter : EmailAuthInput) {
+    public static func requestSendEmail(_ parameter : EmailAuthInput, completion: @escaping (Bool, String) -> ()) {
         AF.request("https://geeksasaeng.shop/email", method: .post,
                    parameters: parameter, encoder: JSONParameterEncoder.default, headers: nil)
         .validate()
@@ -20,15 +20,15 @@ class EmailAuthViewModel {
             case .success(let result):
                 if result.isSuccess! {
                     print("DEBUG: 성공", result.message!)
-                    // 성공했을 때에 성공했다는 토스트 메세지 출력
-                    viewController.showToast(viewController: viewController, message: "인증번호가 전송되었습니다.", font: .customFont(.neoMedium, size: 15), color: .mainColor)
+                    completion(result.isSuccess!, "인증번호가 전송되었습니다.")
+                    
                 } else {
                     print("DEBUG: 실패", result.message!)
-                    viewController.showToast(viewController: viewController, message: result.message ?? "인증번호 전송이 실패했습니다.", font: .customFont(.neoMedium, size: 15), color: UIColor(hex: 0xA8A8A8))
+                    completion(result.isSuccess!, "인증번호 전송이 실패했습니다.")
                 }
             case .failure(let error):
                 print("DEBUG:", error.localizedDescription)
-                viewController.showToast(viewController: viewController, message: "이메일 주소를 다시 확인해 주세요.", font: .customFont(.neoMedium, size: 15), color: UIColor(hex: 0xA8A8A8))
+                completion(false, "이메일 주소를 다시 확인해 주세요.")
             }
         }
     }


### PR DESCRIPTION
Feat
- 매칭 마감하기 뷰 구현
- 회원가입 과정 중 나타나는 모든 뷰들에 스와이프 제스쳐 적용
- 신고하기 완료/실패 시 뜨는 안내뷰 구현
- 학교 이름 목록뷰가 나타났을 때 목록뷰 밖의 화면을 클릭하면 목록뷰가 사라지도록 설정
- 학교 목록에서 학교 이름 선택 시에 emailAddress가 채워지도록 설정
- firestore에서 채팅방의 가장 최근 메세지, 전송 시간 데이터 찾아서 연결

Refactor
- 이메일 인증번호 전송 API 호출 함수 구조 개선
- 다음 버튼 활성화 타이밍 수정 (이메일로 전송이 완료됐을 때에 활성화되도록)
- ReportAPI 구조 개선
- present 타이밍 변경
- 코드 개선