### PR TITLE
Seori

### DIFF
--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Chat/ChattingVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Chat/ChattingVC.swift
@@ -513,8 +513,8 @@ class ChattingViewController: UIViewController {
         navigationItem.setRightBarButton(UIBarButtonItem(image: UIImage(named: "Setting"), style: .plain, target: self, action: #selector(tapOptionButton)), animated: true)
         navigationItem.rightBarButtonItem?.tintColor = .init(hex: 0x2F2F2F)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardUp), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardDown), name: UIResponder.keyboardWillHideNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -561,7 +561,7 @@ class ChattingViewController: UIViewController {
     private func setLayouts() {
         collectionView.snp.makeConstraints { make in
             make.top.left.right.equalToSuperview()
-            make.bottom.equalToSuperview().inset(69)
+            make.bottom.equalTo(bottomView.snp.top).offset(-15)
         }
         
         bottomView.snp.makeConstraints { make in
@@ -774,23 +774,28 @@ class ChattingViewController: UIViewController {
         self.visualEffectView = visualEffectView
     }
     
+    /* 키보드가 올라올 때 실행되는 함수 */
     @objc
-    private func keyboardUp(notification: NSNotification) {
-        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
-           let keyboardRectangle = keyboardFrame.cgRectValue
-            UIView.animate(
-                withDuration: 0.3, animations: {
-                    self.bottomView.transform = CGAffineTransform(translationX: 0, y: -keyboardRectangle.height)
-                    self.collectionView.transform = CGAffineTransform(translationX: 0, y: -keyboardRectangle.height)
-                }
-            )
+    private func keyboardWillShow(sender: NSNotification) {
+        // 1. 키보드의 높이를 구함
+        if let info = sender.userInfo,
+           let keyboardHeight = (info[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue.height {
+            // 2. collectionView의 contentInset bottom 값을 변경하여 키보드 위로 content가 올라갈 수 있도록 함
+            collectionView.contentInset.bottom = keyboardHeight
+            // 3. 키보드 높이만큼 bottomView의 y값을 변경
+            bottomView.transform = CGAffineTransform(translationX: 0, y: -keyboardHeight)
+            
+            // 4. 맨 마지막 아이템으로 스크롤을 해줌으로써 마지막 채팅이 키보드의 위에 뜨도록 함
+            self.collectionView.scrollToItem(at: IndexPath(row: self.contents.count-1, section: 0), at: .top, animated: true)
         }
     }
-    
+
+    /* 키보드가 내려갈 때 실행되는 함수 */
     @objc
-    private func keyboardDown() {
-        self.bottomView.transform = .identity
-        self.collectionView.transform = .identity
+    private func keyboardWillHide(sender: NSNotification) {
+        // collectionView의 contentInset 값과 bottomView의 transform을 원래대로 변경
+        collectionView.contentInset.bottom = 0
+        bottomView.transform = .identity
     }
     
     /* 매칭 마감하기 버튼 누르면 실행되는 함수 */


### PR DESCRIPTION
Refactor
- 채팅 화면에서 키보드 이벤트 발생 시 collection view의 y축이 이동하여 채팅 내용이 가려지는 이슈 해결
-> y축 값 자체를 변경하는 것이 아니라 contentInset을 조절하여 bottom이 키보드 높이만큼 오게 설정함