### PR TITLE
Seori

### DIFF
--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Chat/ChattingListVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Chat/ChattingListVC.swift
@@ -267,12 +267,8 @@ class ChattingListViewController: UIViewController {
                     // TODO: - unreadedMsgCnt 값 구해서 UI 연결하기
     //                self.chattingRoomList[roomIndex].unreadedMsgCnt = ? 이걸 어케 함 채팅방마다?
                     
-                    // TODO: - 채팅방 목록 맨 위로 셀 올리기
-                    
-                    DispatchQueue.main.async {
-                        // 채팅방 목록 리로드
-                        self.chattingTableView.reloadData()
-                    }
+                    // 채팅방 목록 맨 위로 셀 올리기
+                    self.moveToTopOfList(roomIndex: roomIndex)
                 } else {
                     print("[Rabbit] 목록에서 채팅 읽음 수신???", data)
                 }
@@ -508,6 +504,21 @@ class ChattingListViewController: UIViewController {
             } else {
                 cell.receivedTimeString = ""
             }
+        }
+    }
+    
+    // 해당 인덱스의 채팅방을 채팅방 목록의 맨 위로 옮긴다
+    private func moveToTopOfList(roomIndex: Int) {
+        let itemToMove = self.chattingRoomList[roomIndex]
+        self.chattingRoomList.remove(at: roomIndex)
+        self.chattingRoomList.insert(itemToMove, at: 0) // 배열의 첫번째로 넣기
+        let nowIndexPath = IndexPath(row: roomIndex, section: 0)
+        let destinationIndexPath = IndexPath(row: 0, section: 0)
+        
+        DispatchQueue.main.async {
+            // 해당 채팅방을 채팅방 목록 맨 위로 이동
+            self.chattingTableView.moveRow(at: nowIndexPath, to: destinationIndexPath)
+            self.chattingTableView.reloadRows(at: [destinationIndexPath], with: .automatic)
         }
     }
     

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Chat/ChattingVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Chat/ChattingVC.swift
@@ -443,9 +443,6 @@ class ChattingViewController: UIViewController {
     private var conn: RMQConnection? = nil  // rabbitmq 채널 변수
     private let rabbitMQUri = "amqp://\(Keys.idPw)@\(Keys.address)"
     
-    // 프로토콜의 함수를 실행하기 위해 delegate를 설정
-    var delegate: UpdateChattingListDelegate?
-    
     enum MsgType {
         case message
         case sameSenderMessage
@@ -522,9 +519,6 @@ class ChattingViewController: UIViewController {
         
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
-        
-        // 가장 최근 메세지가 변경됐을 확률이 높으니 채팅방 목록 리로드
-        self.delegate?.updateChattingList()
         
         // 사라질 때 다시 탭바 보이게 설정
         self.tabBarController?.tabBar.isHidden = false

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/DeliveryParty/CreateParty/CreatePartySubVC/BankAccountVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/DeliveryParty/CreateParty/CreatePartySubVC/BankAccountVC.swift
@@ -77,13 +77,6 @@ class BankAccountViewController: UIViewController {
         $0.addTarget(self, action: #selector(tapConfirmButton), for: .touchUpInside)
     }
     
-    /* pageLabel: 1/2 */
-    let pageLabel = UILabel().then {
-        $0.text = "1/2"
-        $0.font = .customFont(.neoMedium, size: 13)
-        $0.textColor = UIColor(hex: 0xD8D8D8)
-    }
-    
     // MARK: - Properties
     
     var dormitoryInfo: DormitoryNameResult?
@@ -132,8 +125,7 @@ class BankAccountViewController: UIViewController {
             bankTextField,
             accountNumberTextField,
             guideLabel,
-            confirmButton,
-            pageLabel
+            confirmButton
         ].forEach { view.addSubview($0) }
     }
     
@@ -164,11 +156,6 @@ class BankAccountViewController: UIViewController {
             make.bottom.equalToSuperview().inset(35)
             make.width.equalTo(262)
             make.height.equalTo(51)
-        }
-        
-        pageLabel.snp.makeConstraints { make in
-            make.top.equalTo(confirmButton.snp.bottom).offset(10)
-            make.centerX.equalToSuperview()
         }
         
         guideLabel.snp.makeConstraints { make in

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Splash/SplashPlayerVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Splash/SplashPlayerVC.swift
@@ -17,12 +17,13 @@ class SplashPlayerViewController: UIViewController {
         super.viewDidLoad()
         
         // Lottie AnimationView 생성
-        let animationView = LottieAnimationView(name: "splash")
-
+        let animationView = LottieAnimationView(name: "splash").then {
+            $0.contentMode = .scaleAspectFill
+        }
+        
         // 메인 뷰에 삽입
         view.addSubview(animationView)
         animationView.frame = animationView.superview!.bounds
-        animationView.contentMode = .scaleAspectFit
 
         // 애니메이션 재생 (애니메이션 재생모드 미 설정시 1회)
         animationView.play { (finished) in


### PR DESCRIPTION
Fix
- 채팅방 목록 위에서 아래로 스크롤 시 refresh 기능 제거, 채팅방 목록 셀 중복 append 되는 에러 해결
- 스플래쉬 화면의 animationView의 contentMode 수정으로 양옆 잘리는 현상 해결
 
Feat
- 채팅방 목록에서 메세지 수신 시 수신한 채팅방을 목록의 맨 위로 올리기

Chore
- 계좌 번호 입력 서브뷰의 1/2 텍스트 삭제