### PR TITLE
Seori

### DIFF
--- a/Geeksasaeng/Geeksasaeng/Network/UserInfoAPI.swift
+++ b/Geeksasaeng/Geeksasaeng/Network/UserInfoAPI.swift
@@ -35,6 +35,8 @@ struct UserInfoModelResult: Decodable {
     var reportedCount: Int?
     var fcmToken: String?
     var parties: [UserInfoPartiesModel]?
+    var grade: String?
+    var nextGradeAndRemainCredits: String?
 }
 struct UserInfoPartiesModel: Decodable {
     var id: Int?

--- a/Geeksasaeng/Geeksasaeng/View/Cell/DeliveryParty/PartyTableViewCell.swift
+++ b/Geeksasaeng/Geeksasaeng/View/Cell/DeliveryParty/PartyTableViewCell.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SnapKit
+import Then
 
 class PartyTableViewCell: UITableViewCell {
     
@@ -23,7 +24,9 @@ class PartyTableViewCell: UITableViewCell {
     let timeLabel = UILabel()
     let titleLabel = UILabel()
     let categoryLabel = UILabel()
-    let hashtagLabel = UILabel()
+    let hashtagLabel = UILabel().then {
+        $0.font = .customFont(.neoMedium, size: 12)
+    }
     
     // MARK: - layoutSubviews()
     
@@ -35,7 +38,20 @@ class PartyTableViewCell: UITableViewCell {
         setAttributes()
     }
     
-    // MARK: - Set Functions
+    // MARK: - prepareForReuse()
+    
+    // reuse cell을 사용하기 전에 뷰를 초기화 해주는 것
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        titleLabel.text = ""
+        peopleLabel.text = ""
+        timeLabel.text = ""
+        categoryLabel.text = ""
+        hashtagLabel.textColor = .init(hex: 0xEFEFEF)
+    }
+    
+    // MARK: - Functions
     
     private func addSubViews() {
         [
@@ -87,7 +103,6 @@ class PartyTableViewCell: UITableViewCell {
         timeLabel.setTextAndColorAndFont(textColor: .mainColor, font: .customFont(.neoMedium, size: 14))
         titleLabel.setTextAndColorAndFont(textColor: .black, font: .customFont(.neoBold, size: 18))
         categoryLabel.setTextAndColorAndFont(textColor: UIColor(hex: 0x636363), font: .customFont(.neoMedium, size: 12))
-        hashtagLabel.setTextAndColorAndFont(textColor: UIColor(hex: 0xEFEFEF), font: .customFont(.neoMedium, size: 12))
         hashtagLabel.text = "같이 먹고 싶어요"
         
         self.selectionStyle = .gray

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/DeliveryParty/CreateParty/CreatePartySubVC/BankAccountVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/DeliveryParty/CreateParty/CreatePartySubVC/BankAccountVC.swift
@@ -66,6 +66,7 @@ class BankAccountViewController: UIViewController {
         $0.font = .customFont(.neoMedium, size: 15)
         $0.textColor = .init(hex: 0x5B5B5B)
         $0.addTarget(self, action: #selector(changeValueTitleTextField), for: .editingChanged)
+        $0.keyboardType = .numberPad
         $0.delegate = self
     }
     

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Dormitory/DormitoryVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Dormitory/DormitoryVC.swift
@@ -38,10 +38,14 @@ class DormitoryViewController: UIViewController {
     }
     
     let questionLabel = UILabel().then {
-        $0.text = "현재 어느 기숙사에 거주하고 계신가요?"
         $0.numberOfLines = 2
         $0.font = .customFont(.neoBold, size: 24)
         $0.textColor = .init(hex: 0x2F2F2F)
+        
+        // 행간 설정
+        var paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = 1.2
+        $0.attributedText = NSMutableAttributedString(string: "현재 어느 기숙사에\n거주하고 계신가요?", attributes: [NSAttributedString.Key.paragraphStyle: paragraphStyle])
     }
     
     let guideLabel = UILabel().then {
@@ -99,7 +103,6 @@ class DormitoryViewController: UIViewController {
         questionLabel.snp.makeConstraints { make in
             make.top.equalTo(welcomeLabel.snp.bottom).offset(screenHeight / 12.52)
             make.left.equalToSuperview().inset(screenWidth / 14.03)
-            make.width.equalTo(screenWidth / 2.01)
         }
         
         guideLabel.snp.makeConstraints { make in

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Profile/EditMyInfoVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Profile/EditMyInfoVC.swift
@@ -289,6 +289,11 @@ class EditMyInfoViewController: UIViewController {
     // MARK: - Functions
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         view.endEditing(true)
+        
+        // 블러뷰 클릭 시 pw 확인 뷰 닫기
+        if let touch = touches.first, touch.view == self.visualEffectView {
+            closePasswordCheckView()
+        }
     }
     
     private func setNavigationBar() {
@@ -303,11 +308,6 @@ class EditMyInfoViewController: UIViewController {
     }
     
     private func setAttributes() {
-        /* 화면 터치 반응 설정 */
-        view.isUserInteractionEnabled = true
-        let gesture = UITapGestureRecognizer(target: self, action: #selector(tapViewController))
-        view.addGestureRecognizer(gesture)
-        
         /* 프로필 이미지 뷰 설정 */
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapUserImageView))
         userImageView.addGestureRecognizer(tapGesture)
@@ -404,7 +404,6 @@ class EditMyInfoViewController: UIViewController {
             let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
             visualEffectView.layer.opacity = 0.6
             visualEffectView.frame = view.frame
-            visualEffectView.isUserInteractionEnabled = false
             self.userImageView.isUserInteractionEnabled = false
             view.addSubview(visualEffectView)
             self.visualEffectView = visualEffectView
@@ -660,7 +659,7 @@ class EditMyInfoViewController: UIViewController {
     }
     
     @objc
-    private func tapViewController() {
+    private func closePasswordCheckView() {
         if visualEffectView != nil {
             editConfirmView.removeFromSuperview()
             changeProfileImageView.removeFromSuperview()

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Profile/ProfileVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Profile/ProfileVC.swift
@@ -47,25 +47,22 @@ class ProfileViewController: UIViewController {
         $0.backgroundColor = .init(hex: 0xF8F8F8)
     }
     
+    lazy var gradeLabel = UILabel().then {
+        $0.font = .customFont(.neoBold, size: 12)
+        $0.textColor = .white
+    }
+    lazy var remainLabel = UILabel().then {
+        $0.font = .customFont(.neoMedium, size: 12)
+        $0.textColor = .white
+    }
     /* grade & 복학까지 ~ 가 들어있는 view */
-    let gradeView = UIView().then { view in
+    lazy var gradeView = UIView().then { view in
         view.backgroundColor = .mainColor
         view.layer.masksToBounds = true
         view.layer.cornerRadius = 10
         view.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
         
-        // TODO: - gradeLabel, remainLabel getUserInfo API에서 불러와야 함
-        let gradeLabel = UILabel().then {
-            $0.font = .customFont(.neoBold, size: 12)
-            $0.textColor = .white
-            $0.text = "신입생"
-        }
         let separateImageView = UIImageView(image: UIImage(named: "MyInfoSeparateIcon"))
-        let remainLabel = UILabel().then {
-            $0.font = .customFont(.neoMedium, size: 12)
-            $0.textColor = .white
-            $0.text = "복학까지 5학점 남았어요"
-        }
         let arrowImageView = UIImageView(image: UIImage(named: "MyInfoArrowIcon"))
         
         [ gradeLabel, separateImageView, remainLabel, arrowImageView ].forEach {
@@ -407,8 +404,8 @@ class ProfileViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        // 나의 활동 3개 띄우기
         self.getUserInfo()
+        // 나의 활동 3개 띄우기
         self.getUserActivities()
         
         // 다른 VC에서 여기에 토스트 메세지를 띄우기 위한 옵저버 등록
@@ -440,6 +437,8 @@ class ProfileViewController: UIViewController {
             print(result)
             
             if isSuccess {
+                self.gradeLabel.text = result.grade
+                self.remainLabel.text = result.nextGradeAndRemainCredits
                 self.nicknameLabel.text = result.nickname
                 self.universityLabel.text = result.universityName
                 self.dormitoryLabel.text = result.dormitoryName

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Profile/SubViews/PasswordCheckVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Profile/SubViews/PasswordCheckVC.swift
@@ -11,13 +11,14 @@ import SnapKit
 import Then
 
 class PasswordCheckViewController: UIViewController {
+    
     // MARK: - Properties
+    
     /* 이전 뷰에서 받아오는 properties */
     var dormitoryId: Int?
     var loginId: String?
     var nickname: String?
     var profileImg: UIImage?
-    
     
     // MARK: - SubViews
     

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Profile/SubViews/ProfileCardVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Profile/SubViews/ProfileCardVC.swift
@@ -15,25 +15,22 @@ class ProfileCardViewController: UIViewController {
     
     var blurView: UIVisualEffectView?
     
+    lazy var gradeLabel = UILabel().then {
+        $0.font = .customFont(.neoBold, size: 12)
+        $0.textColor = .white
+    }
+    lazy var remainLabel = UILabel().then {
+        $0.font = .customFont(.neoMedium, size: 12)
+        $0.textColor = .white
+    }
     /* grade & 복학까지 ~ 가 들어있는 view */
-    let gradeView = UIView().then { view in
+    lazy var gradeView = UIView().then { view in
         view.backgroundColor = .mainColor
         view.layer.masksToBounds = true
         view.layer.cornerRadius = 10
         view.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
         
-        // TODO: - gradeLabel, remainLabel getUserInfo API에서 불러와야 함
-        let gradeLabel = UILabel().then {
-            $0.font = .customFont(.neoBold, size: 12)
-            $0.textColor = .white
-            $0.text = "신입생"
-        }
         let separateImageView = UIImageView(image: UIImage(named: "MyInfoSeparateIcon"))
-        let remainLabel = UILabel().then {
-            $0.font = .customFont(.neoMedium, size: 12)
-            $0.textColor = .white
-            $0.text = "복학까지 5학점 남았어요"
-        }
         let arrowImageView = UIImageView(image: UIImage(named: "MyInfoArrowIcon"))
         
         [ gradeLabel, separateImageView, remainLabel, arrowImageView ].forEach {
@@ -84,10 +81,13 @@ class ProfileCardViewController: UIViewController {
             $0.layer.cornerRadius = 54
         }
         
+        // TODO: - 추후에 리팩토링 굳이 api 안 써도 됨 init으로 프로필 화면의 데이터 가져오면 되니까
         UserInfoAPI.getUserInfo { isSuccess, result in
             MyLoadingView.shared.hide()
             
             if isSuccess {
+                self.gradeLabel.text = result.grade
+                self.remainLabel.text = result.nextGradeAndRemainCredits
                 nicknameLabel.text = result.nickname
                 universityLabel.text = result.universityName
                 dormitoryLabel.text = result.dormitoryName
@@ -156,6 +156,7 @@ class ProfileCardViewController: UIViewController {
             $0.textColor = .init(hex: 0xA8A8A8)
         }
         
+        // TODO: - 추후 리팩토링
         UserInfoAPI.getUserInfo { isSuccess, result in
             MyLoadingView.shared.hide()
             

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/EmailAuthVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/EmailAuthVC.swift
@@ -502,7 +502,7 @@ class EmailAuthViewController: UIViewController {
                 if let model = model {
                     // 경우에 맞는 토스트 메세지 출력
                     switch model.code {
-                    case 1001:
+                    case 1802:
                         self.showToast(viewController: self, message: "인증번호가 전송되었습니다", font: .customFont(.neoBold, size: 15), color: .mainColor)
                         // 이미 돌아가고 있는 타이머가 있으면 -> 재전송 버튼 누른 경우
                         if let timer = self.timer {
@@ -516,8 +516,10 @@ class EmailAuthViewController: UIViewController {
                         self.authSendButton.isHidden = true
                         self.authResendButton.isHidden = false
                         self.remainTimeLabel.isHidden = false
-                    case 2015:
-                        self.showToast(viewController: self, message: "일일 최대 전송 횟수를 초과했습니다", font: .customFont(.neoBold, size: 13), color: .init(hex: 0xA8A8A8), width: 248, height: 40)
+                    case 2803:
+                        self.showToast(viewController: self, message: "유효하지 않은 인증번호입니다", font: .customFont(.neoBold, size: 13), color: .init(hex: 0xA8A8A8), width: 248, height: 40)
+                    case 2804:
+                        self.showToast(viewController: self, message: "이메일 인증은 하루 최대 10번입니다", font: .customFont(.neoBold, size: 13), color: .init(hex: 0xA8A8A8), width: 248, height: 40)
                     default:
                         self.showToast(viewController: self, message: "잠시 후에 다시 시도해 주세요", font: .customFont(.neoBold, size: 13), color: .init(hex: 0xA8A8A8), width: 212, height: 40)
                     }

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/EmailAuthVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/EmailAuthVC.swift
@@ -544,6 +544,11 @@ class EmailAuthViewController: UIViewController {
                 MyLoadingView.shared.hide()
                 
                 if isSuccess {
+                    // 인증 완료 텍스트 띄우기
+                    self.remainTimeLabel.text = "성공적으로 인증이 완료되었습니다"
+                    self.timer?.cancel()
+                    self.timer = nil
+                    
                     self.emailId = emailId
                     self.nextButton.setActivatedNextButton()
                 } else {

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/EmailAuthVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/EmailAuthVC.swift
@@ -160,6 +160,7 @@ class EmailAuthViewController: UIViewController {
             string: "입력하세요",
             attributes: [NSAttributedString.Key.foregroundColor: UIColor.init(hex: 0xD8D8D8)]
         )
+        $0.keyboardType = .numberPad
         $0.makeBottomLine()
     }
     

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/NaverRegisterVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/NaverRegisterVC.swift
@@ -176,6 +176,7 @@ class NaverRegisterViewController: UIViewController {
             string: "입력하세요",
             attributes: [NSAttributedString.Key.foregroundColor: UIColor.init(hex: 0xD8D8D8)]
         )
+        $0.keyboardType = .numberPad
         $0.makeBottomLine()
     }
     

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/NaverRegisterVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/NaverRegisterVC.swift
@@ -600,7 +600,7 @@ class NaverRegisterViewController: UIViewController {
                 if let model = model {
                     // 경우에 맞는 토스트 메세지 출력
                     switch model.code {
-                    case 1001:
+                    case 1802:
                         self.showToast(viewController: self, message: "인증번호가 전송되었습니다", font: .customFont(.neoBold, size: 15), color: .mainColor)
                         // 이미 돌아가고 있는 타이머가 있으면 -> 재전송 버튼 누른 경우
                         if let timer = self.timer {
@@ -617,8 +617,10 @@ class NaverRegisterViewController: UIViewController {
                             self.startTimer()
                             self.remainTimeLabel.isHidden = false
                         }
-                    case 2015:
-                        self.showToast(viewController: self, message: "일일 최대 전송 횟수를 초과했습니다", font: .customFont(.neoBold, size: 13), color: .init(hex: 0xA8A8A8), width: 248, height: 40)
+                    case 2803:
+                        self.showToast(viewController: self, message: "유효하지 않은 인증번호입니다", font: .customFont(.neoBold, size: 13), color: .init(hex: 0xA8A8A8), width: 248, height: 40)
+                    case 2804:
+                        self.showToast(viewController: self, message: "이메일 인증은 하루 최대 10번입니다", font: .customFont(.neoBold, size: 13), color: .init(hex: 0xA8A8A8), width: 248, height: 40)
                     default:
                         self.showToast(viewController: self, message: "잠시 후에 다시 시도해 주세요", font: .customFont(.neoBold, size: 13), color: .init(hex: 0xA8A8A8), width: 212, height: 40)
                     }
@@ -642,8 +644,13 @@ class NaverRegisterViewController: UIViewController {
                 MyLoadingView.shared.hide()
                 
                 if isSuccess {
+                    // 인증 완료 텍스트 띄우기
+                    self.remainTimeLabel.text = "성공적으로 인증이 완료되었습니다"
+                    self.timer?.cancel()
+                    self.timer = nil
+                    
                     self.emailId = emailId
-                    self.nextButton.setActivatedButton()
+                    self.nextButton.setActivatedNextButton()
                 } else {
                     self.showToast(viewController: self, message: "인증번호가 틀렸습니다", font: .customFont(.neoMedium, size: 13), color: UIColor(hex: 0xA8A8A8), width: 179, height: 40)
                 }

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/PhoneAuthVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/PhoneAuthVC.swift
@@ -305,7 +305,7 @@ class PhoneAuthViewController: UIViewController {
                     self.phoneNumberId = result?.phoneNumberId
                     self.showNextView()
                 default:
-                    self.showToast(viewController: self, message: message!, font: .customFont(.neoMedium, size: 13), color: UIColor(hex: 0xA8A8A8))
+                    self.showToast(viewController: self, message: message!, font: .customFont(.neoBold, size: 13), color: UIColor(hex: 0xA8A8A8))
                 }
             }
         }

--- a/Geeksasaeng/Geeksasaeng/View/ViewController/Register/PhoneAuthVC.swift
+++ b/Geeksasaeng/Geeksasaeng/View/ViewController/Register/PhoneAuthVC.swift
@@ -47,8 +47,12 @@ class PhoneAuthViewController: UIViewController {
     var phoneNumLabel = UILabel()
     var authLabel = UILabel()
     
-    var phoneNumTextField = UITextField()
-    var authTextField = UITextField()
+    var phoneNumTextField = UITextField().then {
+        $0.keyboardType = .numberPad
+    }
+    var authTextField = UITextField().then {
+        $0.keyboardType = .numberPad
+    }
     
     lazy var authSendButton = UIButton().then {
         $0.setTitle("인증번호 전송", for: .normal)


### PR DESCRIPTION
Fix
- 이메일 인증하기 API 예외처리 코드 수정
- 배달파티 목록 셀 같이 먹어요 해시태그 색 설정 코드 수정, 셀 초기화 코드 추가
- 배경의 블러뷰 클릭 시에만 비번 확인 창 내리기
- 이메일 인증번호 일치 시 textfield 밑에 일치합니다 텍스트 띄우는 걸로 변경
- 다음 버튼 활성화하는 코드 변경

Feat
- 나의 정보 화면, 프로필 카드뷰 화면에 등급 관련 데이터 연결
- 숫자만 들어가야 하는 텍스트 필드에는 숫자 키보드로 띄우기

Style
- 토스트 메세지 폰트 변경